### PR TITLE
Added an Image logger callback for wandb

### DIFF
--- a/configs/callbacks/wandb_callbacks.yaml
+++ b/configs/callbacks/wandb_callbacks.yaml
@@ -25,3 +25,7 @@ save_f1_precision_recall_heatmap_to_wandb:
 
 save_confusion_matrix_to_wandb:
     _target_: src.callbacks.wandb_callbacks.LogConfusionMatrixToWandb
+    
+log_images:
+    _target_: src.callbacks.wandb_callbacks.ImagePredictionLogger
+    num_samples: 8

--- a/src/callbacks/wandb_callbacks.py
+++ b/src/callbacks/wandb_callbacks.py
@@ -204,7 +204,7 @@ class ImagePredictionLogger(Callback):
        https://wandb.ai/wandb/wandb-lightning/reports/Image-Classification-using-PyTorch-Lightning--VmlldzoyODk1NzY
     """
 
-    def __init__(self, num_samples):
+    def __init__(self, num_samples: int = 8):
         super().__init__()
         self.num_samples = num_samples
         self.ready = True
@@ -237,4 +237,3 @@ class ImagePredictionLogger(Callback):
                                                 preds[:self.num_samples],
                                                 val_labels[:self.num_samples])]
             })
-

--- a/src/callbacks/wandb_callbacks.py
+++ b/src/callbacks/wandb_callbacks.py
@@ -207,6 +207,7 @@ class ImagePredictionLogger(Callback):
     def __init__(self, num_samples):
         super().__init__()
         self.num_samples = num_samples
+        self.ready = True
 
     def on_sanity_check_start(self, trainer, pl_module):
         self.ready = False
@@ -216,7 +217,6 @@ class ImagePredictionLogger(Callback):
         self.ready = True
 
     def on_validation_epoch_end(self, trainer, pl_module):
-<<<<<<< HEAD
         if self.ready:
             logger = get_wandb_logger(trainer=trainer)
             experiment = logger.experiment
@@ -237,3 +237,4 @@ class ImagePredictionLogger(Callback):
                                                 preds[:self.num_samples],
                                                 val_labels[:self.num_samples])]
             })
+

--- a/src/callbacks/wandb_callbacks.py
+++ b/src/callbacks/wandb_callbacks.py
@@ -216,20 +216,24 @@ class ImagePredictionLogger(Callback):
         self.ready = True
 
     def on_validation_epoch_end(self, trainer, pl_module):
-        # get a validation batch from the calidation dat loader
-        val_samples = next(iter(trainer.datamodule.val_dataloader()))
-        val_imgs, val_labels = val_samples[0], val_samples[1]
+        if self.ready:
+            logger = get_wandb_logger(trainer=trainer)
+            experiment = logger.experiment
+            
+            # get a validation batch from the validation dat loader
+            val_samples = next(iter(trainer.datamodule.val_dataloader()))
+            val_imgs, val_labels = val_samples
 
-        # run the batch through the network
-        val_imgs = val_imgs.to(device=pl_module.device)
-        logits = pl_module(val_imgs)
-        preds = torch.argmax(logits, axis=-1)
+            # run the batch through the network
+            val_imgs = val_imgs.to(device=pl_module.device)
+            logits = pl_module(val_imgs)
+            preds = torch.argmax(logits, axis=-1)
 
-        # log the images as wandb Image
-        trainer.logger.experiment[0].log({
-            'Images':[wandb.Image(x, caption=f'Pred:{pred}, Label:{y}')
-            for x, pred, y in zip(val_imgs[:self.num_samples],
-                                preds[:self.num_samples],
-                                val_labels[:self.num_samples])]
+            # log the images as wandb Image
+            experiment.log({
+                f"Images/{experiment.name}":[wandb.Image(x, caption=f"Pred:{pred}, Label:{y}")
+                          for x, pred, y in zip(val_imgs[:self.num_samples],
+                                                preds[:self.num_samples],
+                                                val_labels[:self.num_samples])]
             })
 

--- a/src/callbacks/wandb_callbacks.py
+++ b/src/callbacks/wandb_callbacks.py
@@ -236,21 +236,4 @@ class ImagePredictionLogger(Callback):
                           for x, pred, y in zip(val_imgs[:self.num_samples],
                                                 preds[:self.num_samples],
                                                 val_labels[:self.num_samples])]
-=======
-        # get a validation batch from the validation dataloader
-        val_samples = next(iter(trainer.datamodule.val_dataloader()))
-        val_imgs, val_labels = val_samples
-
-        # run the batch through the network
-        val_imgs = val_imgs.to(device=pl_module.device)
-        logits = pl_module(val_imgs)
-        preds = torch.argmax(logits, axis=-1)
-
-        # log the images as wandb Image
-        trainer.logger.experiment[0].log({
-            'Images':[wandb.Image(x, caption=f'Pred:{pred}, Label:{y}')
-            for x, pred, y in zip(val_imgs[:self.num_samples],
-                                preds[:self.num_samples],
-                                val_labels[:self.num_samples])]
->>>>>>> a4921ef30b9212be966e11470dceb9164be0cce2
             })


### PR DESCRIPTION
Hi,
As mentioned some time ago in issue #127 here is a custom callback that logs a batch of images together with their label and the corresponding prediction to wandb. 

I think it would also be nice to have a callback for object detection and semantic segmentation.
Maybe I could do this in the coming time.