### PR TITLE
Clarify meaning of EarlyStopping patience

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -13,5 +13,5 @@ early_stopping:
   _target_: pytorch_lightning.callbacks.EarlyStopping
   monitor: "val/acc" # name of the logged metric which determines when model is improving
   mode: "max" # can be "max" or "min"
-  patience: 100 # how many epochs of not improving until training stops
+  patience: 100 # how many validation epochs of not improving until training stops
   min_delta: 0 # minimum change in the monitored metric needed to qualify as an improvement


### PR DESCRIPTION
Specify that EarlyStopping patience is counted in validation epochs and not in training epochs.