### PR TITLE
Installation local config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ dmypy.json
 .idea/
 
 # Lightning-Hydra-Template
+configs/local/default.yaml
 data/
 logs/
 wandb/

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ dmypy.json
 .idea/
 
 # Lightning-Hydra-Template
-configs/local/
+configs/local/default.yaml
 data/
 logs/
 wandb/

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ dmypy.json
 .idea/
 
 # Lightning-Hydra-Template
-configs/local/default.yaml
+configs/local/
 data/
 logs/
 wandb/

--- a/README.md
+++ b/README.md
@@ -504,38 +504,6 @@ ignore_warnings: True
 
 <br>
 
-### Local Installation Configuration
-
-Location: [configs/local](configs/local)<br>
-Sometimes certain installations require specific default configurarion overrides, e.g. when you are running on a cluster, or on a machine with a certain harddrive configuration.
-
-For each of these scenarios, a file in `configs/local` can be created and checked into Git. They can be enabled by linking or copying them to `configs/local/default.yaml`, which is automatically loaded but is not tracked by Git.
-
-<details>
-<summary><b>Simple example</b></summary>
-
-```yaml
-# @package _global_
-
-defaults:
-  - override /hydra/launcher@_here_: submitit_slurm
-
-data_dir: /mnt/scratch/data/
-
-hydra:
-  launcher:
-    timeout_min: 1440
-    gpus_per_task: 1
-    gres: gpu:1
-  job:
-    env_set:
-      MY_VAR: /home/user/my/system/path
-      MY_KEY: asdgjhawi8y23ihsghsueity23ihwd
-```
-
-</details>
-
-
 ### Experiment Configuration
 
 Location: [configs/experiment](configs/experiment)<br>
@@ -636,6 +604,39 @@ logger:
     name: ${name}
     tags: ["best_model", "mnist"]
     notes: "Description of this model."
+```
+
+</details>
+
+<br>
+
+### Local Configuration
+
+Location: [configs/local](configs/local) <br>
+Some configurations are user/machine specific (e.g. configuration of local cluster, or harddrive paths on a specific machine).
+
+For such scenarios, a file `configs/local/default.yaml` can be created which is automatically loaded but not tracked by Git.
+
+<details>
+<summary><b>Local Slurm cluster config example</b></summary>
+
+```yaml
+# @package _global_
+
+defaults:
+  - override /hydra/launcher@_here_: submitit_slurm
+
+data_dir: /mnt/scratch/data/
+
+hydra:
+  launcher:
+    timeout_min: 1440
+    gpus_per_task: 1
+    gres: gpu:1
+  job:
+    env_set:
+      MY_VAR: /home/user/my/system/path
+      MY_KEY: asdgjhawi8y23ihsghsueity23ihwd
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The directory structure of new project looks like this:
 │   ├── datamodule              <- Datamodule configs
 │   ├── experiment              <- Experiment configs
 │   ├── hparams_search          <- Hyperparameter search configs
+│   ├── local                   <- Installation specific configs
 │   ├── logger                  <- Logger configs
 │   ├── mode                    <- Running mode configs
 │   ├── model                   <- Model configs
@@ -503,6 +504,34 @@ ignore_warnings: True
 
 <br>
 
+### Local Installation Configuration
+
+Location: [configs/local](configs/local)<br>
+Sometimes certain installations require specific default configurarion overrides, e.g. when you are running on a cluster, or on a machine with a certain harddrive configuration.
+
+For each of these scenarios, a file in `configs/local` can be created and checked into Git. They can be enabled by linking or copying them to `configs/local/default.yaml`, which is automatically loaded but is not tracked by Git.
+
+<details>
+<summary><b>Simple Slurm example</b></summary>
+
+```yaml
+# @package _global_
+
+defaults:
+  - override /hydra/launcher@_here_: submitit_slurm
+
+data_dir: /mnt/scratch/data/
+
+hydra:
+  launcher:
+    timeout_min: 1440
+    gpus_per_task: 1
+    gres: gpu:1
+```
+
+</details>
+
+
 ### Experiment Configuration
 
 Location: [configs/experiment](configs/experiment)<br>
@@ -905,12 +934,12 @@ The `config.yaml` from `.hydra` folder contains all overriden parameters and sec
 
 <br>
 
-<!-- 
+<!--
 ### Extra Features
 - Loading environment variables from `.env` file
 - Forcing debug-friendly configuration when using `trainer.fast_dev_run=True` (disables GPU and multiprocessing)
 -->
- 
+
 ### Limitations
 
 - Currently, template doesn't support k-fold cross validation, but it's possible to achieve it with Lightning Loop interface. See the [official example](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/loop_examples/kfold.py). Implementing it requires rewriting the training pipeline.

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ logger:
 ### Local Configuration
 
 Location: [configs/local](configs/local) <br>
-Some configurations are user/machine specific (e.g. configuration of local cluster, or harddrive paths on a specific machine). For such scenarios, a file `configs/local/default.yaml` can be created which is automatically loaded but not tracked by Git.
+Some configurations are user/machine/installation specific (e.g. configuration of local cluster, or harddrive paths on a specific machine). For such scenarios, a file `configs/local/default.yaml` can be created which is automatically loaded but not tracked by Git.
 
 <details>
 <summary><b>Local Slurm cluster config example</b></summary>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The directory structure of new project looks like this:
 │   ├── datamodule              <- Datamodule configs
 │   ├── experiment              <- Experiment configs
 │   ├── hparams_search          <- Hyperparameter search configs
-│   ├── local                   <- Installation specific configs
+│   ├── local                   <- Local configs
 │   ├── logger                  <- Logger configs
 │   ├── mode                    <- Running mode configs
 │   ├── model                   <- Model configs
@@ -613,9 +613,7 @@ logger:
 ### Local Configuration
 
 Location: [configs/local](configs/local) <br>
-Some configurations are user/machine specific (e.g. configuration of local cluster, or harddrive paths on a specific machine).
-
-For such scenarios, a file `configs/local/default.yaml` can be created which is automatically loaded but not tracked by Git.
+Some configurations are user/machine specific (e.g. configuration of local cluster, or harddrive paths on a specific machine). For such scenarios, a file `configs/local/default.yaml` can be created which is automatically loaded but not tracked by Git.
 
 <details>
 <summary><b>Local Slurm cluster config example</b></summary>

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Sometimes certain installations require specific default configurarion overrides
 For each of these scenarios, a file in `configs/local` can be created and checked into Git. They can be enabled by linking or copying them to `configs/local/default.yaml`, which is automatically loaded but is not tracked by Git.
 
 <details>
-<summary><b>Simple Slurm example</b></summary>
+<summary><b>Simple example</b></summary>
 
 ```yaml
 # @package _global_
@@ -527,6 +527,10 @@ hydra:
     timeout_min: 1440
     gpus_per_task: 1
     gres: gpu:1
+  job:
+    env_set:
+      MY_VAR: /home/user/my/system/path
+      MY_KEY: asdgjhawi8y23ihsghsueity23ihwd
 ```
 
 </details>

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -14,6 +14,9 @@ defaults:
   - experiment: null
   - hparams_search: null
 
+  # optional local config
+  - optional local: default.yaml
+
   # enable color logging
   - override hydra/hydra_logging: colorlog
   - override hydra/job_logging: colorlog


### PR DESCRIPTION
Sometimes it is really handy to have installation-specific local config files -- they are usually automatically loaded but are not tracked by Git.

This template could make use of such a thing, and I believe I have found a nice solution in this PR: A new directory `configs/local/` could host as many example local files as you like, and if you copy any of them to `configs/local/default.yaml`, it will be automatically picked up by Hydra.

Importantly, `configs/local/default.yaml` is not tracked by Git, so your different installations on different machines will not produce merge conflicts.

In these local config files you could then set things that are specific to each installation:

 - Special hard drive (and therefore `data_dir`) configurations
 - Special launchers, e.g. on Slurm-managed clusters
 - Special GPU config values that never change

and others.