### PR TITLE
Instantiate model using Hydra

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,12 +425,15 @@ All PyTorch Lightning modules are dynamically instantiated from module paths spe
 
 ```yaml
 _target_: src.models.mnist_model.MNISTLitModule
-input_size: 784
-lin1_size: 256
-lin2_size: 256
-lin3_size: 256
-output_size: 10
 lr: 0.001
+
+net:
+  _target_: src.models.components.simple_dense_net.SimpleDenseNet
+  input_size: 784
+  lin1_size: 256
+  lin2_size: 256
+  lin3_size: 256
+  output_size: 10
 ```
 
 Using this config we can instantiate the object with the following line:
@@ -556,10 +559,11 @@ trainer:
   gradient_clip_val: 0.5
 
 model:
-  lin1_size: 128
-  lin2_size: 256
-  lin3_size: 64
   lr: 0.002
+  net:
+    lin1_size: 128
+    lin2_size: 256
+    lin3_size: 64
 
 datamodule:
   batch_size: 64
@@ -723,13 +727,13 @@ hydra:
         type: float
         low: 0.0001
         high: 0.2
-      model.lin1_size:
+      model.net.lin1_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]
-      model.lin2_size:
+      model.net.lin2_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]
-      model.lin3_size:
+      model.net.lin3_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]
 ```

--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -24,10 +24,11 @@ trainer:
   gradient_clip_val: 0.5
 
 model:
-  lin1_size: 128
-  lin2_size: 256
-  lin3_size: 64
   lr: 0.002
+  net:
+    lin1_size: 128
+    lin2_size: 256
+    lin3_size: 64
 
 datamodule:
   batch_size: 64

--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -49,12 +49,12 @@ hydra:
         type: float
         low: 0.0001
         high: 0.2
-      model.lin1_size:
+      model.net.lin1_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]
-      model.lin2_size:
+      model.net.lin2_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]
-      model.lin3_size:
+      model.net.lin3_size:
         type: categorical
         choices: [32, 64, 128, 256, 512]

--- a/configs/model/mnist.yaml
+++ b/configs/model/mnist.yaml
@@ -1,9 +1,11 @@
 _target_: src.models.mnist_module.MNISTLitModule
-
-input_size: 784
-lin1_size: 256
-lin2_size: 256
-lin3_size: 256
-output_size: 10
 lr: 0.001
 weight_decay: 0.0005
+
+net:
+  _target_: src.models.components.simple_dense_net.SimpleDenseNet
+  input_size: 784
+  lin1_size: 256
+  lin2_size: 256
+  lin3_size: 256
+  output_size: 10

--- a/src/models/components/simple_dense_net.py
+++ b/src/models/components/simple_dense_net.py
@@ -2,20 +2,27 @@ from torch import nn
 
 
 class SimpleDenseNet(nn.Module):
-    def __init__(self, hparams: dict):
+    def __init__(
+        self,
+        input_size: int = 784,
+        lin1_size: int = 256,
+        lin2_size: int = 256,
+        lin3_size: int = 256,
+        output_size: int = 10,
+    ):
         super().__init__()
 
         self.model = nn.Sequential(
-            nn.Linear(hparams["input_size"], hparams["lin1_size"]),
-            nn.BatchNorm1d(hparams["lin1_size"]),
+            nn.Linear(input_size, lin1_size),
+            nn.BatchNorm1d(lin1_size),
             nn.ReLU(),
-            nn.Linear(hparams["lin1_size"], hparams["lin2_size"]),
-            nn.BatchNorm1d(hparams["lin2_size"]),
+            nn.Linear(lin1_size, lin2_size),
+            nn.BatchNorm1d(lin2_size),
             nn.ReLU(),
-            nn.Linear(hparams["lin2_size"], hparams["lin3_size"]),
-            nn.BatchNorm1d(hparams["lin3_size"]),
+            nn.Linear(lin2_size, lin3_size),
+            nn.BatchNorm1d(lin3_size),
             nn.ReLU(),
-            nn.Linear(hparams["lin3_size"], hparams["output_size"]),
+            nn.Linear(lin3_size, output_size),
         )
 
     def forward(self, x):

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -25,11 +25,7 @@ class MNISTLitModule(LightningModule):
 
     def __init__(
         self,
-        input_size: int = 784,
-        lin1_size: int = 256,
-        lin2_size: int = 256,
-        lin3_size: int = 256,
-        output_size: int = 10,
+        net: torch.nn.Module,
         lr: float = 0.001,
         weight_decay: float = 0.0005,
     ):
@@ -39,7 +35,7 @@ class MNISTLitModule(LightningModule):
         # it also ensures init params will be stored in ckpt
         self.save_hyperparameters(logger=False)
 
-        self.model = SimpleDenseNet(hparams=self.hparams)
+        self.net = net
 
         # loss function
         self.criterion = torch.nn.CrossEntropyLoss()
@@ -54,7 +50,7 @@ class MNISTLitModule(LightningModule):
         self.val_acc_best = MaxMetric()
 
     def forward(self, x: torch.Tensor):
-        return self.model(x)
+        return self.net(x)
 
     def step(self, batch: Any):
         x, y = batch


### PR DESCRIPTION
Hydra allows us to recursively instantiate classes, which means we don't need to pass `SimpleDenseNet` parameters to `MNISTLitModel`, but can let Hydra create the class for us.

This cleans up the code, makes it more modular and reusable, and neatly groups the parameters together.

This leaves one open question though: what happens in

```python
self.save_hyperparameters(logger=False)
```

Does it pick up on those nested hyper parameters?