### PR TITLE
log config to machine readable format

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -112,6 +112,9 @@ def print_config(
     with open("config_tree.log", "w") as fp:
         rich.print(tree, file=fp)
 
+    with open("config.yaml", "w") as fp:
+        OmegaConf.save(config, f=fp, resolve=resolve)
+
 
 @rank_zero_only
 def log_hyperparameters(


### PR DESCRIPTION
It would be great if the params of a run were saved in a machine readable format, not just a tree file. I am not sure why Hydra only does this for multiruns and not for single runs. Maybe I missed it somewhere?

If Hydra indeed doesn't do this, this PR contains a change that does that.

P.S. I have also opened a feature request about this upstream: https://github.com/facebookresearch/hydra/issues/1907