### PR TITLE
Avoid conflict between isort and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: 5.8.0
     hooks:
       - id: isort
+        args: ["--profile", "black", "--filter-files"]
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Currently isort and black sometimes conflict with each other. black will change import type to version-1 and isort will change it to version-2 which can't pass the test of black. So we can never commit. Adding this arg can avoid conflict.