### PR TITLE
Remove deprecated trainer arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,6 @@ python run.py +trainer.fast_dev_run=true
 # raise exception if there are any numerical anomalies in tensors, like NaN or +/-inf
 python run.py +trainer.detect_anomaly=true
 
-# print full weight summary of all PyTorch modules
-python run.py trainer.weights_summary="full"
-
 # print execution time profiling after training ends
 python run.py +trainer.profiler="simple"
 

--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -16,5 +16,9 @@ early_stopping:
   patience: 100 # how many validation epochs of not improving until training stops
   min_delta: 0 # minimum change in the monitored metric needed to qualify as an improvement
 
+model_summary:
+  _target_: pytorch_lightning.callbacks.RichModelSummary
+  max_depth: 1
+
 rich_progress_bar:
   _target_: pytorch_lightning.callbacks.RichProgressBar

--- a/configs/trainer/debug.yaml
+++ b/configs/trainer/debug.yaml
@@ -7,8 +7,6 @@ min_epochs: 1
 max_epochs: 2
 
 # prints
-progress_bar_refresh_rate: null
-weights_summary: "full"
 profiler: null
 
 # debugs

--- a/configs/trainer/default.yaml
+++ b/configs/trainer/default.yaml
@@ -5,9 +5,7 @@ gpus: 0
 min_epochs: 1
 max_epochs: 10
 
-progress_bar_refresh_rate: 5
 resume_from_checkpoint: null
-weights_summary: "full"
 
 # number of validation steps to execute at the beginning of the training
 num_sanity_val_steps: 0


### PR DESCRIPTION
`progress_bar_refresh_rate` and `weights_summary` give deprecation warnings, and will be deprecated in PyTorch Lightning 1.7: https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.trainer.trainer.html
Their recommendations (pass as `Callback`) seem to already be implemented here, so I just removed the arguments from the config. 

Example output from running `python run.py ignore_warnings=false trainer.max_epochs=1 trainer.gpus=1`

Before change:
```
~/Development/lightning-hydra-template$ python run.py ignore_warnings=false trainer.max_epochs=1 trainer.gpus=1
CONFIG                                                                                                                                                        
├── trainer                                                                                                                                                   
│   └── _target_: pytorch_lightning.Trainer                                                                                                                   
│       gpus: 1                                                                                                                                               
│       min_epochs: 1                                                                                                                                         
│       max_epochs: 1                                                                                                                                         
│       progress_bar_refresh_rate: 5                                                                                                                          
│       resume_from_checkpoint: null                                                                                                                          
│       weights_summary: full                                                                                                                                 
│       num_sanity_val_steps: 0                                                                                                                               
│                                                                                                                                                             
├── model                                                                                                                                                     
│   └── _target_: src.models.mnist_model.MNISTLitModel                                                                                                        
│       input_size: 784                                                                                                                                       
│       lin1_size: 256                                                                                                                                        
│       lin2_size: 256                                                                                                                                        
│       lin3_size: 256                                                                                                                                        
│       output_size: 10                                                                                                                                       
│       lr: 0.001                                                                                                                                             
│       weight_decay: 0.0005                                                                                                                                  
│                                                                                                                                                             
├── datamodule                                                                                                                                                
│   └── _target_: src.datamodules.mnist_datamodule.MNISTDataModule                                                                                            
│       data_dir: /home/charles/Development/lightning-hydra-template/data/                                                                                    
│       batch_size: 64                                                                                                                                        
│       train_val_test_split:                                                                                                                                 
│       - 55000                                                                                                                                               
│       - 5000                                                                                                                                                
│       - 10000                                                                                                                                               
│       num_workers: 0                                                                                                                                        
│       pin_memory: false                                                                                                                                     
│                                                                                                                                                             
├── callbacks                                                                                                                                                 
│   └── model_checkpoint:                                                                                                                                     
│         _target_: pytorch_lightning.callbacks.ModelCheckpoint                                                                                               
│         monitor: val/acc                                                                                                                                    
│         mode: max                                                                                                                                           
│         save_top_k: 1                                                                                                                                       
│         save_last: true                                                                                                                                     
│         verbose: false                                                                                                                                      
│         dirpath: checkpoints/                                                                                                                               
│         filename: epoch_{epoch:03d}                                                                                                                         
│         auto_insert_metric_name: false                                                                                                                      
│       early_stopping:                                                                                                                                       
│         _target_: pytorch_lightning.callbacks.EarlyStopping                                                                                                 
│         monitor: val/acc                                                                                                                                    
│         mode: max                                                                                                                                           
│         patience: 100                                                                                                                                       
│         min_delta: 0                                                                                                                                        
│       rich_progress_bar:                                                                                                                                    
│         _target_: pytorch_lightning.callbacks.RichProgressBar                                                                                               
│                                                                                                                                                             
├── logger                                                                                                                                                    
│   └── None                                                                                                                                                  
├── test_after_training                                                                                                                                       
│   └── True                                                                                                                                                  
├── seed                                                                                                                                                      
│   └── None                                                                                                                                                  
└── name                                                                                                                                                      
    └── None                                                                                                                                                  
[2021-12-13 11:53:19,955][src.train][INFO] - Instantiating datamodule <src.datamodules.mnist_datamodule.MNISTDataModule>
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/core/datamodule.py:175: LightningDeprecationWarning: DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7.
  rank_zero_deprecation("DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7.")
[2021-12-13 11:53:19,958][src.train][INFO] - Instantiating model <src.models.mnist_model.MNISTLitModel>
[2021-12-13 11:53:19,968][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.ModelCheckpoint>
[2021-12-13 11:53:19,969][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.EarlyStopping>
[2021-12-13 11:53:19,970][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.RichProgressBar>
[2021-12-13 11:53:19,970][src.train][INFO] - Instantiating trainer <pytorch_lightning.Trainer>
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/connectors/callback_connector.py:90: LightningDeprecationWarning: Setting `Trainer(progress_bar_refresh_rate=5)` is deprecated in v1.5 and will be removed in v1.7. Please pass `pytorch_lightning.callbacks.progress.TQDMProgressBar` with `refresh_rate` directly to the Trainer's `callbacks` argument instead. Or, to disable the progress bar pass `enable_progress_bar = False` to the Trainer.
  rank_zero_deprecation(
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/connectors/callback_connector.py:187: LightningDeprecationWarning: Setting `Trainer(weights_summary=full)` is deprecated in v1.5 and will be removed in v1.7. Please pass `pytorch_lightning.callbacks.model_summary.ModelSummary` with `max_depth` directly to the Trainer's `callbacks` argument instead.
  rank_zero_deprecation(
[2021-12-13 11:53:20,000][pytorch_lightning.utilities.distributed][INFO] - GPU available: True, used: True
[2021-12-13 11:53:20,000][pytorch_lightning.utilities.distributed][INFO] - TPU available: False, using: 0 TPU cores
[2021-12-13 11:53:20,001][pytorch_lightning.utilities.distributed][INFO] - IPU available: False, using: 0 IPUs
[2021-12-13 11:53:20,001][src.train][INFO] - Logging hyperparameters!
[2021-12-13 11:53:20,001][src.train][INFO] - Starting training!
[2021-12-13 11:53:20,069][pytorch_lightning.accelerators.gpu][INFO] - LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
┏━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃    ┃ Name          ┃ Type             ┃ Params ┃
┡━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ 0  │ model         │ SimpleDenseNet   │  336 K │
│ 1  │ model.model   │ Sequential       │  336 K │
│ 2  │ model.model.0 │ Linear           │  200 K │
│ 3  │ model.model.1 │ BatchNorm1d      │    512 │
│ 4  │ model.model.2 │ ReLU             │      0 │
│ 5  │ model.model.3 │ Linear           │ 65.8 K │
│ 6  │ model.model.4 │ BatchNorm1d      │    512 │
│ 7  │ model.model.5 │ ReLU             │      0 │
│ 8  │ model.model.6 │ Linear           │ 65.8 K │
│ 9  │ model.model.7 │ BatchNorm1d      │    512 │
│ 10 │ model.model.8 │ ReLU             │      0 │
│ 11 │ model.model.9 │ Linear           │  2.6 K │
│ 12 │ criterion     │ CrossEntropyLoss │      0 │
│ 13 │ train_acc     │ Accuracy         │      0 │
│ 14 │ val_acc       │ Accuracy         │      0 │
│ 15 │ test_acc      │ Accuracy         │      0 │
│ 16 │ val_acc_best  │ MaxMetric        │      0 │
└────┴───────────────┴──────────────────┴────────┘
Trainable params: 336 K                                                                                                                                       
Non-trainable params: 0                                                                                                                                       
Total params: 336 K                                                                                                                                           
Total estimated model params size (MB): 1                                                                                                                     
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, val_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
Epoch 0    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 939/939 0:00:13 • 0:00:00 71.27it/s loss: 0.12 v_num:  
[2021-12-13 11:53:34,996][src.train][INFO] - Starting testing!
[2021-12-13 11:53:34,997][pytorch_lightning.utilities.distributed][INFO] - Restoring states from the checkpoint path at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-53-18/checkpoints/epoch_000.ckpt
[2021-12-13 11:53:35,000][pytorch_lightning.accelerators.gpu][INFO] - LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
[2021-12-13 11:53:35,004][pytorch_lightning.utilities.distributed][INFO] - Loaded model weights from checkpoint at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-53-18/checkpoints/epoch_000.ckpt
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, test_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
--------------------------------------------------------------------------------
DATALOADER:0 TEST RESULTS
{'test/acc': 0.9650999903678894, 'test/loss': 0.11356159299612045}
--------------------------------------------------------------------------------
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 157/157 0:00:01 • 0:00:00 91.18it/s  
[2021-12-13 11:53:36,750][src.train][INFO] - Finalizing!
[2021-12-13 11:53:36,750][src.train][INFO] - Best model ckpt at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-53-18/checkpoints/epoch_000.ckpt
```

After change

```
~/Development/lightning-hydra-template$ python run.py ignore_warnings=false trainer.max_epochs=1 trainer.gpus=1
CONFIG                                                                                                                                                        
├── trainer                                                                                                                                                   
│   └── _target_: pytorch_lightning.Trainer                                                                                                                   
│       gpus: 1                                                                                                                                               
│       min_epochs: 1                                                                                                                                         
│       max_epochs: 1                                                                                                                                         
│       resume_from_checkpoint: null                                                                                                                          
│       num_sanity_val_steps: 0                                                                                                                               
│                                                                                                                                                             
├── model                                                                                                                                                     
│   └── _target_: src.models.mnist_model.MNISTLitModel                                                                                                        
│       input_size: 784                                                                                                                                       
│       lin1_size: 256                                                                                                                                        
│       lin2_size: 256                                                                                                                                        
│       lin3_size: 256                                                                                                                                        
│       output_size: 10                                                                                                                                       
│       lr: 0.001                                                                                                                                             
│       weight_decay: 0.0005                                                                                                                                  
│                                                                                                                                                             
├── datamodule                                                                                                                                                
│   └── _target_: src.datamodules.mnist_datamodule.MNISTDataModule                                                                                            
│       data_dir: /home/charles/Development/lightning-hydra-template/data/                                                                                    
│       batch_size: 64                                                                                                                                        
│       train_val_test_split:                                                                                                                                 
│       - 55000                                                                                                                                               
│       - 5000                                                                                                                                                
│       - 10000                                                                                                                                               
│       num_workers: 0                                                                                                                                        
│       pin_memory: false                                                                                                                                     
│                                                                                                                                                             
├── callbacks                                                                                                                                                 
│   └── model_checkpoint:                                                                                                                                     
│         _target_: pytorch_lightning.callbacks.ModelCheckpoint                                                                                               
│         monitor: val/acc                                                                                                                                    
│         mode: max                                                                                                                                           
│         save_top_k: 1                                                                                                                                       
│         save_last: true                                                                                                                                     
│         verbose: false                                                                                                                                      
│         dirpath: checkpoints/                                                                                                                               
│         filename: epoch_{epoch:03d}                                                                                                                         
│         auto_insert_metric_name: false                                                                                                                      
│       early_stopping:                                                                                                                                       
│         _target_: pytorch_lightning.callbacks.EarlyStopping                                                                                                 
│         monitor: val/acc                                                                                                                                    
│         mode: max                                                                                                                                           
│         patience: 100                                                                                                                                       
│         min_delta: 0                                                                                                                                        
│       rich_progress_bar:                                                                                                                                    
│         _target_: pytorch_lightning.callbacks.RichProgressBar                                                                                               
│                                                                                                                                                             
├── logger                                                                                                                                                    
│   └── None                                                                                                                                                  
├── test_after_training                                                                                                                                       
│   └── True                                                                                                                                                  
├── seed                                                                                                                                                      
│   └── None                                                                                                                                                  
└── name                                                                                                                                                      
    └── None                                                                                                                                                  
[2021-12-13 11:43:03,988][src.train][INFO] - Instantiating datamodule <src.datamodules.mnist_datamodule.MNISTDataModule>
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/core/datamodule.py:175: LightningDeprecationWarning: DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7.
  rank_zero_deprecation("DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7.")
[2021-12-13 11:43:03,991][src.train][INFO] - Instantiating model <src.models.mnist_model.MNISTLitModel>
[2021-12-13 11:43:04,000][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.ModelCheckpoint>
[2021-12-13 11:43:04,001][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.EarlyStopping>
[2021-12-13 11:43:04,002][src.train][INFO] - Instantiating callback <pytorch_lightning.callbacks.RichProgressBar>
[2021-12-13 11:43:04,002][src.train][INFO] - Instantiating trainer <pytorch_lightning.Trainer>
[2021-12-13 11:43:04,017][pytorch_lightning.utilities.distributed][INFO] - GPU available: True, used: True
[2021-12-13 11:43:04,017][pytorch_lightning.utilities.distributed][INFO] - TPU available: False, using: 0 TPU cores
[2021-12-13 11:43:04,017][pytorch_lightning.utilities.distributed][INFO] - IPU available: False, using: 0 IPUs
[2021-12-13 11:43:04,017][src.train][INFO] - Logging hyperparameters!
[2021-12-13 11:43:04,018][src.train][INFO] - Starting training!
[2021-12-13 11:43:04,086][pytorch_lightning.accelerators.gpu][INFO] - LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
┏━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃   ┃ Name         ┃ Type             ┃ Params ┃
┡━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ 0 │ model        │ SimpleDenseNet   │  336 K │
│ 1 │ criterion    │ CrossEntropyLoss │      0 │
│ 2 │ train_acc    │ Accuracy         │      0 │
│ 3 │ val_acc      │ Accuracy         │      0 │
│ 4 │ test_acc     │ Accuracy         │      0 │
│ 5 │ val_acc_best │ MaxMetric        │      0 │
└───┴──────────────┴──────────────────┴────────┘
Trainable params: 336 K                                                                                                                                       
Non-trainable params: 0                                                                                                                                       
Total params: 336 K                                                                                                                                           
Total estimated model params size (MB): 1                                                                                                                     
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, val_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
Epoch 0    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 939/939 0:00:12 • 0:00:00 74.94it/s loss: 0.116 v_num:  
[2021-12-13 11:43:18,386][src.train][INFO] - Starting testing!
[2021-12-13 11:43:18,387][pytorch_lightning.utilities.distributed][INFO] - Restoring states from the checkpoint path at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-43-02/checkpoints/epoch_000.ckpt
[2021-12-13 11:43:18,390][pytorch_lightning.accelerators.gpu][INFO] - LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
[2021-12-13 11:43:18,395][pytorch_lightning.utilities.distributed][INFO] - Loaded model weights from checkpoint at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-43-02/checkpoints/epoch_000.ckpt
/home/charles/anaconda3/envs/nlb/lib/python3.8/site-packages/pytorch_lightning/trainer/data_loading.py:116: UserWarning: The dataloader, test_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 12 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
--------------------------------------------------------------------------------
DATALOADER:0 TEST RESULTS
{'test/acc': 0.9690999984741211, 'test/loss': 0.10726992040872574}
--------------------------------------------------------------------------------
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 157/157 0:00:01 • 0:00:00 96.48it/s  
[2021-12-13 11:43:20,044][src.train][INFO] - Finalizing!
[2021-12-13 11:43:20,045][src.train][INFO] - Best model ckpt at /home/charles/Development/lightning-hydra-template/logs/runs/2021-12-13/11-43-02/checkpoints/epoch_000.ckpt
```