### PR TITLE
fix : Not print best ckeckpoint

### DIFF
--- a/src/training_pipeline.py
+++ b/src/training_pipeline.py
@@ -114,7 +114,7 @@ def train(config: DictConfig) -> Optional[float]:
     )
 
     # Print path to best checkpoint
-    if not config.trainer.get("fast_dev_run") and config.trainer.get("train"):
+    if not config.trainer.get("fast_dev_run") and config.get("train"):
         log.info(f"Best model ckpt at {trainer.checkpoint_callback.best_model_path}")
 
     # Return metric score for hyperparameter optimization


### PR DESCRIPTION
Because of this template, I use effectively pl and hydra. Thanks a lot. But there is a little issue in src/training_pipeline.py.

On the 123rd line, code wants to print the best checkpoint path. But config.trainer doesn't have "train" key, so it can't print message. Although I tried to add "train" in configs/trainer/default.yaml, but error.

You seem to have intended "config.get("train")", not "config.trainer.get("train"). 