### PR TITLE
Fix logging path in mlflow

### DIFF
--- a/configs/logger/mlflow.yaml
+++ b/configs/logger/mlflow.yaml
@@ -3,8 +3,7 @@
 mlflow:
   _target_: pytorch_lightning.loggers.mlflow.MLFlowLogger
   experiment_name: ${name}
-  tracking_uri: null
+  tracking_uri: ${original_work_dir}/logs/mlflow/mlruns # run `mlflow ui` command inside the `logs/mlflow/` dir to open the UI
   tags: null
-  save_dir: ./mlruns
   prefix: ""
   artifact_location: null


### PR DESCRIPTION
This PR makes MLFlow logger place all run logs in the same directory so UI can read all of them at once.