### PR TITLE
Add docformatter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 
   # python docstring formatting
   - repo: https://github.com/myint/docformatter
-    rev: v1.3.1
+    rev: v1.4
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries, "99", --wrap-descriptions, "92"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,13 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 
+  # python docstring formatting
+  - repo: https://github.com/myint/docformatter
+    rev: v1.3.1
+    hooks:
+      - id: docformatter
+        args: [--in-place, --wrap-summaries, "99", --wrap-descriptions, "92"]
+
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.5.1

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ pre-commit install
 ```
 
 After that your code will be automatically reformatted on every new commit.<br>
-Currently template contains configurations of **black** (python code formatting), **isort** (python import sorting), **flake8** (python code analysis), **prettier** (yaml formating) and **nbstripout** (clearing output from jupyter notebooks). <br>
+Currently template contains configurations of **black** (python code formatting), **isort** (python import sorting), **docformatter** (python docstring formatting) **flake8** (python code analysis), **prettier** (yaml formating) and **nbstripout** (clearing output from jupyter notebooks). <br>
 
 To reformat all files in the project use command:
 

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ pre-commit install
 ```
 
 After that your code will be automatically reformatted on every new commit.<br>
-Currently template contains configurations of **black** (python code formatting), **isort** (python import sorting), **docformatter** (python docstring formatting) **flake8** (python code analysis), **prettier** (yaml formating) and **nbstripout** (clearing output from jupyter notebooks). <br>
+Currently template contains configurations of **black** (python code formatting), **isort** (python import sorting), **docformatter** (python docstring formatting), **flake8** (python code analysis), **prettier** (yaml formating) and **nbstripout** (clearing output from jupyter notebooks). <br>
 
 To reformat all files in the project use command:
 

--- a/src/datamodules/mnist_datamodule.py
+++ b/src/datamodules/mnist_datamodule.py
@@ -60,12 +60,11 @@ class MNISTDataModule(LightningDataModule):
         MNIST(self.hparams.data_dir, train=False, download=True)
 
     def setup(self, stage: Optional[str] = None):
-        """Load data.
+        """Load data. Set variables: `self.data_train`, `self.data_val`, `self.data_test`.
 
-        Set variables: `self.data_train`, `self.data_val`, `self.data_test`. This method is
-        called by lightning twice for `trainer.fit()` and `trainer.test()`, so be careful if
-        you do a random split! The `stage` can be used to differentiate whether it's called
-        before trainer.fit()` or `trainer.test()`.
+        This method is called by lightning twice for `trainer.fit()` and `trainer.test()`,
+        so be careful if you do a random split! The `stage` can be used to differentiate
+        whether it's called before trainer.fit()` or `trainer.test()`.
         """
 
         # load datasets only if they're not loaded already

--- a/src/datamodules/mnist_datamodule.py
+++ b/src/datamodules/mnist_datamodule.py
@@ -8,8 +8,7 @@ from torchvision.transforms import transforms
 
 
 class MNISTDataModule(LightningDataModule):
-    """
-    Example of LightningDataModule for MNIST dataset.
+    """Example of LightningDataModule for MNIST dataset.
 
     A DataModule implements 5 key methods:
         - prepare_data (things to do on 1 GPU/TPU, not on every GPU/TPU in distributed mode)
@@ -52,15 +51,22 @@ class MNISTDataModule(LightningDataModule):
         return 10
 
     def prepare_data(self):
-        """Download data if needed. This method is called only from a single GPU.
-        Do not use it to assign state (self.x = y)."""
+        """Download data if needed.
+
+        This method is called only from a single GPU.
+        Do not use it to assign state (self.x = y).
+        """
         MNIST(self.hparams.data_dir, train=True, download=True)
         MNIST(self.hparams.data_dir, train=False, download=True)
 
     def setup(self, stage: Optional[str] = None):
-        """Load data. Set variables: `self.data_train`, `self.data_val`, `self.data_test`.
-        This method is called by lightning twice for `trainer.fit()` and `trainer.test()`, so be careful if you do a random split!
-        The `stage` can be used to differentiate whether it's called before trainer.fit()` or `trainer.test()`."""
+        """Load data.
+
+        Set variables: `self.data_train`, `self.data_val`, `self.data_test`. This method is
+        called by lightning twice for `trainer.fit()` and `trainer.test()`, so be careful if
+        you do a random split! The `stage` can be used to differentiate whether it's called
+        before trainer.fit()` or `trainer.test()`.
+        """
 
         # load datasets only if they're not loaded already
         if not self.data_train and not self.data_val and not self.data_test:

--- a/src/datamodules/mnist_datamodule.py
+++ b/src/datamodules/mnist_datamodule.py
@@ -62,9 +62,9 @@ class MNISTDataModule(LightningDataModule):
     def setup(self, stage: Optional[str] = None):
         """Load data. Set variables: `self.data_train`, `self.data_val`, `self.data_test`.
 
-        This method is called by lightning twice for `trainer.fit()` and `trainer.test()`,
-        so be careful if you do a random split! The `stage` can be used to differentiate
-        whether it's called before trainer.fit()` or `trainer.test()`.
+        This method is called by lightning when doing `trainer.fit()` and `trainer.test()`,
+        so be careful not to execute the random split twice! The `stage` can be used to
+        differentiate whether it's called before trainer.fit()` or `trainer.test()`.
         """
 
         # load datasets only if they're not loaded already

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -9,8 +9,7 @@ from src.models.components.simple_dense_net import SimpleDenseNet
 
 
 class MNISTLitModule(LightningModule):
-    """
-    Example of LightningModule for MNIST classification.
+    """Example of LightningModule for MNIST classification.
 
     A LightningModule organizes your PyTorch code into 5 sections:
         - Computations (init).

--- a/src/testing_pipeline.py
+++ b/src/testing_pipeline.py
@@ -12,8 +12,7 @@ log = utils.get_logger(__name__)
 
 
 def test(config: DictConfig) -> None:
-    """Contains minimal example of the testing pipeline.
-    Evaluates given checkpoint on a testset.
+    """Contains minimal example of the testing pipeline. Evaluates given checkpoint on a testset.
 
     Args:
         config (DictConfig): Configuration composed by Hydra.

--- a/src/training_pipeline.py
+++ b/src/training_pipeline.py
@@ -18,8 +18,8 @@ log = utils.get_logger(__name__)
 
 
 def train(config: DictConfig) -> Optional[float]:
-    """Contains the training pipeline.
-    Can additionally evaluate model on a testset, using best weights achieved during training.
+    """Contains the training pipeline. Can additionally evaluate model on a testset, using best
+    weights achieved during training.
 
     Args:
         config (DictConfig): Configuration composed by Hydra.

--- a/tests/helpers/module_available.py
+++ b/tests/helpers/module_available.py
@@ -14,7 +14,6 @@ def _module_available(module_path: str) -> bool:
     True
     >>> _module_available('bla.bla')
     False
-
     """
     try:
         return find_spec(module_path) is not None

--- a/tests/helpers/runif.py
+++ b/tests/helpers/runif.py
@@ -20,8 +20,8 @@ from tests.helpers.module_available import (
 
 
 class RunIf:
-    """
-    RunIf wrapper for conditional skipping of tests.
+    """RunIf wrapper for conditional skipping of tests.
+
     Fully compatible with `@pytest.mark`.
 
     Example:
@@ -30,7 +30,6 @@ class RunIf:
         @pytest.mark.parametrize("arg1", [1.0, 2.0])
         def test_wrapper(arg1):
             assert arg1 > 0
-
     """
 
     def __new__(


### PR DESCRIPTION
This PR adds `docformatter` to pre-commit hooks for automatic formatting of python dosctrings. Additionally reformats docstrings in all files.