### PR TITLE
fix val_best_acc

### DIFF
--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -51,6 +51,9 @@ class MNISTLitModule(LightningModule):
     def forward(self, x: torch.Tensor):
         return self.net(x)
 
+    def on_train_start(self):
+        self.val_acc_best.reset()
+
     def step(self, batch: Any):
         x, y = batch
         logits = self.forward(x)

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -52,6 +52,8 @@ class MNISTLitModule(LightningModule):
         return self.net(x)
 
     def on_train_start(self):
+        # by default lightning executes validation step sanity checks before training starts,
+        # so we need to make sure val_acc_best doesn't store accuracy from these checks
         self.val_acc_best.reset()
 
     def step(self, batch: Any):
@@ -70,7 +72,7 @@ class MNISTLitModule(LightningModule):
         self.log("train/acc", acc, on_step=False, on_epoch=True, prog_bar=True)
 
         # we can return here dict with any tensors
-        # and then read it in some callback or in `training_epoch_end()`` below
+        # and then read it in some callback or in `training_epoch_end()` below
         # remember to always return loss from `training_step()` or else backpropagation will fail!
         return {"loss": loss, "preds": preds, "targets": targets}
 


### PR DESCRIPTION
Hello there,

I have found a small bug in the sample model file.

https://github.com/ashleve/lightning-hydra-template/blob/31f90df4a18c3e0b6914099e440cf2bb9178417a/src/models/mnist_module.py#L88-L91

the `validation_epoch_end` would run after sanity check, usually the sanity check step is small, the val accuracy could have higher rate than at beginning of the training, moreover if the `val_acc` is 1 in sanctity check, the `val_acc_best` would be always 1.