### PR TITLE
Refactor ckpt_path

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -49,6 +49,9 @@ train: True
 # lightning chooses best weights based on the metric specified in checkpoint callback
 test: True
 
+# checkpoint path for resuming training
+ckpt_path: null
+
 # seed for random number generators in pytorch, numpy and python.random
 seed: null
 

--- a/configs/trainer/default.yaml
+++ b/configs/trainer/default.yaml
@@ -4,9 +4,3 @@ gpus: 0
 
 min_epochs: 1
 max_epochs: 10
-
-# number of validation steps to execute at the beginning of the training
-# num_sanity_val_steps: 0
-
-# ckpt path
-resume_from_checkpoint: null

--- a/src/testing_pipeline.py
+++ b/src/testing_pipeline.py
@@ -21,13 +21,11 @@ def test(config: DictConfig) -> None:
         None
     """
 
+    assert config.ckpt_path
+
     # Set seed for random number generators in pytorch, numpy and python.random
     if config.get("seed"):
         seed_everything(config.seed, workers=True)
-
-    # Convert relative ckpt path to absolute path if necessary
-    if not os.path.isabs(config.ckpt_path):
-        config.ckpt_path = os.path.join(hydra.utils.get_original_cwd(), config.ckpt_path)
 
     # Init lightning datamodule
     log.info(f"Instantiating datamodule <{config.datamodule._target_}>")

--- a/src/training_pipeline.py
+++ b/src/training_pipeline.py
@@ -32,13 +32,6 @@ def train(config: DictConfig) -> Optional[float]:
     if config.get("seed"):
         seed_everything(config.seed, workers=True)
 
-    # Convert relative ckpt path to absolute path if necessary
-    ckpt_path = config.trainer.get("resume_from_checkpoint")
-    if ckpt_path and not os.path.isabs(ckpt_path):
-        config.trainer.resume_from_checkpoint = os.path.join(
-            hydra.utils.get_original_cwd(), ckpt_path
-        )
-
     # Init lightning datamodule
     log.info(f"Instantiating datamodule <{config.datamodule._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(config.datamodule)
@@ -83,7 +76,7 @@ def train(config: DictConfig) -> Optional[float]:
     # Train the model
     if config.get("train"):
         log.info("Starting training!")
-        trainer.fit(model=model, datamodule=datamodule)
+        trainer.fit(model=model, datamodule=datamodule, ckpt_path=config.get("ckpt_path"))
 
     # Get metric score for hyperparameter optimization
     optimized_metric = config.get("optimized_metric")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,7 +1,9 @@
+import os
 import logging
 import warnings
 from typing import List, Sequence
 
+import hydra
 import pytorch_lightning as pl
 import rich.syntax
 import rich.tree
@@ -39,6 +41,7 @@ def extras(config: DictConfig) -> None:
     Utilities:
     - Ignoring python warnings
     - Rich config printing
+    - Converting relative ckpt path to absolute path
     """
 
     # disable python warnings if <config.ignore_warnings=True>
@@ -50,6 +53,12 @@ def extras(config: DictConfig) -> None:
     if config.get("print_config"):
         log.info("Printing config tree with Rich! <config.print_config=True>")
         print_config(config, resolve=True)
+
+    # convert ckpt path to absolute path
+    ckpt_path = config.get("ckpt_path")
+    if ckpt_path and not os.path.isabs(ckpt_path):
+        log.info("Converting ckpt path to absolute path! <config.ckpt_path=...>")
+        config.ckpt_path = os.path.join(hydra.utils.get_original_cwd(), ckpt_path)
 
 
 @rank_zero_only


### PR DESCRIPTION
Move conversion of relative ckpt path to absolute path to `utils.extras()`.

Deprecate `resume_from_checkpoint` for the sake of `ckpt_path` for compatibility with lightning v1.6.