### PR TITLE
Move optimized metric retrieval to `utils.get_metric_value()`

### DIFF
--- a/src/training_pipeline.py
+++ b/src/training_pipeline.py
@@ -69,13 +69,8 @@ def train(config: DictConfig) -> Optional[float]:
         trainer.fit(model=model, datamodule=datamodule, ckpt_path=config.get("ckpt_path"))
 
     # Get metric score for hyperparameter optimization
-    optimized_metric = config.get("optimized_metric")
-    if optimized_metric and optimized_metric not in trainer.callback_metrics:
-        raise Exception(
-            "Metric for hyperparameter optimization not found! "
-            "Make sure the `optimized_metric` in `hparams_search` config is correct!"
-        )
-    score = trainer.callback_metrics.get(optimized_metric)
+    metric_name = config.get("optimized_metric")
+    score = utils.get_metric_value(metric_name, trainer) if metric_name else None
 
     # Test the model
     if config.get("test"):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -162,6 +162,22 @@ def log_hyperparameters(
     trainer.logger.log_hyperparams(hparams)
 
 
+def get_metric_value(metric_name: str, trainer: pl.Trainer) -> float:
+    """Retrieves value of the metric logged in LightningModule.
+
+    Args:
+        metric_name (str): Name of the metric.
+        trainer (pl.Trainer): Lightning Trainer instance.
+    """
+    if metric_name not in trainer.callback_metrics:
+        raise Exception(
+            f"Metric value not found! <metric_name={metric_name}>\n"
+            "Make sure metric name logged in LightningModule is correct!\n"
+            "Make sure the `optimized_metric` name in `hparams_search` config is correct!"
+        )
+    return trainer.callback_metrics[metric_name]
+
+
 def finish(
     config: DictConfig,
     model: pl.LightningModule,


### PR DESCRIPTION
Move hyperparameter search `optimized_metric` retrieval to `utils.get_metric_value()`.