### PR TITLE
Remove `_convert_=partial` from trainer instantiation

### DIFF
--- a/src/testing_pipeline.py
+++ b/src/testing_pipeline.py
@@ -1,4 +1,3 @@
-import os
 from typing import List
 
 import hydra

--- a/src/training_pipeline.py
+++ b/src/training_pipeline.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Optional
 
 import hydra
@@ -40,9 +39,7 @@ def train(cfg: DictConfig) -> Optional[float]:
 
     # init lightning trainer
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
-    trainer: Trainer = hydra.utils.instantiate(
-        cfg.trainer, callbacks=callbacks, logger=logger, _convert_="partial"
-    )
+    trainer: Trainer = hydra.utils.instantiate(cfg.trainer, callbacks=callbacks, logger=logger)
 
     # send hyperparameters to loggers
     log.info("Logging hyperparameters!")


### PR DESCRIPTION
`_convert_=partial` in trainer instantiation was needed to ensure the weight averaging flag doesn't crash the run.

The flag has been deprecated so it can be removed now.