### PR TITLE
Improve trainer configs

### DIFF
--- a/configs/trainer/ddp.yaml
+++ b/configs/trainer/ddp.yaml
@@ -1,6 +1,16 @@
 defaults:
   - default.yaml
 
-gpus: 4
-strategy: ddp
+# mixed precision for extra speed-up
+# precision: 16
+
+# use "ddp_spawn" instead of "ddp",
+# it's slower but normal "ddp" currently doesn't work ideally with hydra
+# https://github.com/facebookresearch/hydra/issues/2070
+# https://pytorch-lightning.readthedocs.io/en/latest/accelerators/gpu_intermediate.html#distributed-data-parallel-spawn
+strategy: ddp_spawn
+
+accelerator: gpu
+devices: 4
+num_nodes: 1
 sync_batchnorm: True

--- a/configs/trainer/ddp_sim.yaml
+++ b/configs/trainer/ddp_sim.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - default.yaml
+
+# simulate DDP on CPU, useful for debugging
+accelerator: cpu
+devices: 4
+strategy: ddp_spawn

--- a/configs/trainer/default.yaml
+++ b/configs/trainer/default.yaml
@@ -1,9 +1,11 @@
 _target_: pytorch_lightning.Trainer
 
 default_root_dir: ${paths.output_dir}
-enable_model_summary: False
-
-gpus: 0
 
 min_epochs: 1 # prevents early stopping
 max_epochs: 10
+
+accelerator: cpu
+devices: 1
+
+enable_model_summary: False

--- a/configs/trainer/gpu.yaml
+++ b/configs/trainer/gpu.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - default.yaml
+
+accelerator: gpu
+devices: 1


### PR DESCRIPTION
Gets rid of deprecated `trainer.gpus` argument.

Adds `trainer.accelerator` and `trainer.devices`.

Adds `ddp_sim.yaml` for simulating DDP on CPU

Adds `gpus.yaml` as a default trainer GPU config.