### PR TITLE
Configure Optimizer in Hydra using _partial_: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ When running `python train.py` you should see something like this:
 > Hydra allows you to easily overwrite any parameter defined in your config.
 
 ```bash
-python train.py trainer.max_epochs=20 model.lr=1e-4
+python train.py trainer.max_epochs=20 model.optimizer.lr=1e-4
 ```
 
 > You can also add new parameters with `+` sign.
@@ -337,7 +337,7 @@ python test.py ckpt_path="/path/to/ckpt/name.ckpt"
 ```bash
 # this will run 6 experiments one after the other,
 # each with different combination of batch_size and learning rate
-python train.py -m datamodule.batch_size=32,64,128 model.lr=0.001,0.0005
+python train.py -m datamodule.batch_size=32,64,128 model.optimizer.lr=0.001,0.0005
 ```
 
 > ⚠️ This sweep is not failure resistant (if one job crashes than the whole sweep crashes).
@@ -425,7 +425,12 @@ All PyTorch Lightning modules are dynamically instantiated from module paths spe
 
 ```yaml
 _target_: src.models.mnist_model.MNISTLitModule
-lr: 0.001
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.001
+  weight_decay: 0.0
 
 net:
   _target_: src.models.components.simple_dense_net.SimpleDenseNet
@@ -559,7 +564,8 @@ trainer:
   gradient_clip_val: 0.5
 
 model:
-  lr: 0.002
+  opimtimizer:
+    lr: 0.002
   net:
     lin1_size: 128
     lin2_size: 256
@@ -723,7 +729,7 @@ hydra:
       datamodule.batch_size:
         type: categorical
         choices: [32, 64, 128]
-      model.lr:
+      model.optimizer.lr:
         type: float
         low: 0.0001
         high: 0.2

--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -23,7 +23,8 @@ trainer:
   gradient_clip_val: 0.5
 
 model:
-  lr: 0.002
+  optimizer:
+    lr: 0.002
   net:
     lin1_size: 128
     lin2_size: 256

--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -44,7 +44,7 @@ hydra:
 
     # define hyperparameter search spacee
     params:
-      model.lr: interval(0.0001, 0.1)
+      model.optimizer.lr: interval(0.0001, 0.1)
       datamodule.batch_size: choice(32, 64, 128, 256)
       model.net.lin1_size: choice(64, 128, 256)
       model.net.lin2_size: choice(64, 128, 256)

--- a/configs/model/mnist.yaml
+++ b/configs/model/mnist.yaml
@@ -1,6 +1,11 @@
 _target_: src.models.mnist_module.MNISTLitModule
-lr: 0.001
-weight_decay: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.001
+  weight_decay: 0.0
+
 net:
   _target_: src.models.components.simple_dense_net.SimpleDenseNet
   input_size: 784

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -115,7 +115,7 @@ class MNISTLitModule(LightningModule):
             https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         """
         return {
-            "optimizer": self.hparams.optimizer(params=self.parameters())
+            "optimizer": self.hparams.optimizer(params=self.parameters()),
         }
 
 

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -24,8 +24,7 @@ class MNISTLitModule(LightningModule):
     def __init__(
         self,
         net: torch.nn.Module,
-        lr: float = 0.001,
-        weight_decay: float = 0.0005,
+        optimizer: torch.optim.Optimizer,
     ):
         super().__init__()
 
@@ -115,9 +114,9 @@ class MNISTLitModule(LightningModule):
         Examples:
             https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         """
-        return torch.optim.Adam(
-            params=self.parameters(), lr=self.hparams.lr, weight_decay=self.hparams.weight_decay
-        )
+        return {
+            "optimizer": self.hparams.optimizer(params=self.parameters())
+        }
 
 
 if __name__ == "__main__":

--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -28,7 +28,7 @@ def test_default_sweep(tmp_path):
         startfile,
         "-m",
         "hydra.sweep.dir=" + str(tmp_path),
-        "model.lr=0.01,0.02,0.03",
+        "model.optimizer.lr=0.01,0.02,0.03",
         "trainer=default",
     ] + overrides
 


### PR DESCRIPTION
In order to quickly and conveniently swap out optimizers and schedulers I'd recommend parameterizing them using Hydra.

We need a feature that was introduced in Hydra 1.2: [Support for the `_partial_` keyword](https://github.com/facebookresearch/hydra/issues/1283)