### PR TITLE
Add flags to improve hparams_search

### DIFF
--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -5,6 +5,10 @@
 
 defaults:
   - override /hydra/sweeper: optuna
+  
+  # make sure to override the default sampler, when you want to try other sampler, like RandomSampler
+  # https://github.com/facebookresearch/hydra/blob/8b9ce30802165c1b24dbf4e513eb78d8ca8cacd6/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py#L144
+  # - override /hydra/sweeper/sampler: random
 
 # choose metric which will be optimized by Optuna
 # make sure this is the correct name of some metric logged in lightning module!
@@ -36,7 +40,7 @@ hydra:
     # choose Optuna hyperparameter sampler
     # docs: https://optuna.readthedocs.io/en/stable/reference/samplers.html
     sampler:
-      _target_: optuna.samplers.TPESampler
+      _target_: optuna.samplers.TPESampler  # or optuna.samplers.RandomSampler
       seed: 12345
       n_startup_trials: 10 # number of random sampling runs before optimization starts
 

--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -5,11 +5,8 @@
 
 defaults:
   - override /hydra/sweeper: optuna
-  
-  # make sure to override the default sampler, when you want to try other sampler, like RandomSampler
-  # https://github.com/facebookresearch/hydra/blob/8b9ce30802165c1b24dbf4e513eb78d8ca8cacd6/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py#L144
-  # - override /hydra/sweeper/sampler: random
-
+  - override /hydra/sweeper/sampler: tpe # set random if use RandomSampler
+ 
 # choose metric which will be optimized by Optuna
 # make sure this is the correct name of some metric logged in lightning module!
 optimized_metric: "val/acc_best"


### PR DESCRIPTION
Hi,

With many people interested in the hydra sampler,  we may consider adding examples for other samplers.

As mentioned [here](https://github.com/facebookresearch/hydra/issues/2003#issuecomment-1027300706), Hydra selects the *TPE sampler* by default. If we want to use **RandomSampler**, we need to override [defaults](https://github.com/facebookresearch/hydra/blob/8b9ce30802165c1b24dbf4e513eb78d8ca8cacd6/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py#L144).

Therefore, I add the obvious note [here](https://github.com/ashleve/lightning-hydra-template/blob/6a92395ed6afd573fa44dd3a054a603acbdcac06/configs/hparams_search/mnist_optuna.yaml#L6) to increase the generality of this code.

