### PR TITLE
Add sampler override to default hparams_search config

### DIFF
--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -6,7 +6,7 @@
 defaults:
   - override /hydra/sweeper: optuna
 
-  # override the default sampler if you want to try other sampler, such as random for RandomSampler
+  # override `tpe` to `random` to execute random search (without optimization)
   - override /hydra/sweeper/sampler: tpe
 
 # choose metric which will be optimized by Optuna

--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -5,7 +5,7 @@
 
 defaults:
   - override /hydra/sweeper: optuna
-  
+
   # override the default sampler if you want to try other sampler, such as random for RandomSampler
   - override /hydra/sweeper/sampler: tpe
 

--- a/configs/hparams_search/mnist_optuna.yaml
+++ b/configs/hparams_search/mnist_optuna.yaml
@@ -5,6 +5,9 @@
 
 defaults:
   - override /hydra/sweeper: optuna
+  
+  # override the default sampler if you want to try other sampler, such as random for RandomSampler
+  - override /hydra/sweeper/sampler: tpe
 
 # choose metric which will be optimized by Optuna
 # make sure this is the correct name of some metric logged in lightning module!


### PR DESCRIPTION
Hi,

I made a new PR for [release/1.4.0](https://github.com/ashleve/lightning-hydra-template/tree/release/1.4)

I remove this [link](https://github.com/facebookresearch/hydra/blob/8b9ce30802165c1b24dbf4e513eb78d8ca8cacd6/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py#L144) because it is too long.

