### PR TITLE
Group callbacks config into separate files

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -1,5 +1,11 @@
+defaults:
+  - model_checkpoint.yaml
+  - early_stopping.yaml
+  - model_summary.yaml
+  - rich_progress_bar.yaml
+  - _self_
+
 model_checkpoint:
-  _target_: pytorch_lightning.callbacks.ModelCheckpoint
   monitor: "val/acc" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   save_top_k: 1 # save k best models (determined by above metric)
@@ -10,15 +16,9 @@ model_checkpoint:
   auto_insert_metric_name: False
 
 early_stopping:
-  _target_: pytorch_lightning.callbacks.EarlyStopping
   monitor: "val/acc" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   patience: 100 # how many validation epochs of not improving until training stops
-  min_delta: 0 # minimum change in the monitored metric needed to qualify as an improvement
 
 model_summary:
-  _target_: pytorch_lightning.callbacks.RichModelSummary
   max_depth: -1
-
-rich_progress_bar:
-  _target_: pytorch_lightning.callbacks.RichProgressBar

--- a/configs/callbacks/early_stopping.yaml
+++ b/configs/callbacks/early_stopping.yaml
@@ -1,0 +1,15 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.EarlyStopping.html#pytorch_lightning.callbacks.EarlyStopping
+
+early_stopping:
+  _target_: pytorch_lightning.callbacks.EarlyStopping
+  monitor: ???
+  min_delta: 0.
+  patience: 3
+  verbose: False
+  mode: "min"
+  strict: True
+  check_finite: True
+  stopping_threshold: null
+  divergence_threshold: null
+  check_on_train_epoch_end: null
+  log_rank_zero_only: False

--- a/configs/callbacks/model_checkpoint.yaml
+++ b/configs/callbacks/model_checkpoint.yaml
@@ -1,0 +1,17 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint
+
+model_checkpoint:
+  _target_: pytorch_lightning.callbacks.ModelCheckpoint
+  dirpath: null
+  filename: null
+  monitor: null
+  verbose: False
+  save_last: null
+  save_top_k: 1
+  mode: "min"
+  auto_insert_metric_name: True
+  save_weights_only: False
+  every_n_train_steps: null
+  train_time_interval: null
+  every_n_epochs: null
+  save_on_train_epoch_end: null

--- a/configs/callbacks/model_summary.yaml
+++ b/configs/callbacks/model_summary.yaml
@@ -1,0 +1,5 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichModelSummary.html#pytorch_lightning.callbacks.RichModelSummary
+
+model_summary:
+  _target_: pytorch_lightning.callbacks.RichModelSummary
+  max_depth: 1

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,0 +1,4 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichProgressBar.html#pytorch_lightning.callbacks.RichProgressBar
+
+rich_progress_bar:
+  _target_: pytorch_lightning.callbacks.RichProgressBar


### PR DESCRIPTION
write all callbacks config in just one file is not very clear, i have seperate different callback into their own file, and so if one wants to change some callback, for example model_checkpoint, he can look at model_checkpoint.yaml and just modify the parameters he want in default.yaml