### PR TITLE
Group callbacks config into separate files

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -1,5 +1,11 @@
+defaults:
+  - model_checkpoint.yaml
+  - early_stopping.yaml
+  - model_summary.yaml
+  - rich_progress_bar.yaml
+  - _self_
+
 model_checkpoint:
-  _target_: pytorch_lightning.callbacks.ModelCheckpoint
   monitor: "val/acc" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   save_top_k: 1 # save k best models (determined by above metric)
@@ -10,15 +16,10 @@ model_checkpoint:
   auto_insert_metric_name: False
 
 early_stopping:
-  _target_: pytorch_lightning.callbacks.EarlyStopping
   monitor: "val/acc" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   patience: 100 # how many validation epochs of not improving until training stops
-  min_delta: 0 # minimum change in the monitored metric needed to qualify as an improvement
+  min_delta: 0. # minimum change in the monitored metric needed to qualify as an improvement
 
 model_summary:
-  _target_: pytorch_lightning.callbacks.RichModelSummary
   max_depth: -1
-
-rich_progress_bar:
-  _target_: pytorch_lightning.callbacks.RichProgressBar

--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -6,20 +6,17 @@ defaults:
   - _self_
 
 model_checkpoint:
-  monitor: "val/acc" # name of the logged metric which determines when model is improving
-  mode: "max" # "max" means higher metric value is better, can be also "min"
-  save_top_k: 1 # save k best models (determined by above metric)
-  save_last: True # additionaly always save model from last epoch
-  verbose: False
   dirpath: ${paths.output_dir}/checkpoints
   filename: "epoch_{epoch:03d}"
+  monitor: "val/acc"
+  mode: "max"
+  save_last: True
   auto_insert_metric_name: False
 
 early_stopping:
-  monitor: "val/acc" # name of the logged metric which determines when model is improving
-  mode: "max" # "max" means higher metric value is better, can be also "min"
-  patience: 100 # how many validation epochs of not improving until training stops
-  min_delta: 0. # minimum change in the monitored metric needed to qualify as an improvement
+  monitor: "val/acc"
+  patience: 100
+  mode: "max"
 
 model_summary:
   max_depth: -1

--- a/configs/callbacks/early_stopping.yaml
+++ b/configs/callbacks/early_stopping.yaml
@@ -1,0 +1,15 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.EarlyStopping.html#pytorch_lightning.callbacks.EarlyStopping
+
+early_stopping:
+  _target_: pytorch_lightning.callbacks.EarlyStopping
+  monitor: ???
+  min_delta: 0.
+  patience: 3
+  verbose: False
+  mode: "min"
+  strict: True
+  check_finite: True
+  stopping_threshold: null
+  divergence_threshold: null
+  check_on_train_epoch_end: null
+  log_rank_zero_only: False

--- a/configs/callbacks/early_stopping.yaml
+++ b/configs/callbacks/early_stopping.yaml
@@ -12,4 +12,4 @@ early_stopping:
   stopping_threshold: null
   divergence_threshold: null
   check_on_train_epoch_end: null
-  log_rank_zero_only: False
+  # log_rank_zero_only: False  # this keyword argument isn't available in stable version

--- a/configs/callbacks/early_stopping.yaml
+++ b/configs/callbacks/early_stopping.yaml
@@ -1,15 +1,17 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.EarlyStopping.html#pytorch_lightning.callbacks.EarlyStopping
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.EarlyStopping.html
 
+# Monitor a metric and stop training when it stops improving.
+# Look at the above link for more detailed information.
 early_stopping:
   _target_: pytorch_lightning.callbacks.EarlyStopping
-  monitor: ???
-  min_delta: 0.
-  patience: 3
-  verbose: False
-  mode: "min"
-  strict: True
-  check_finite: True
-  stopping_threshold: null
-  divergence_threshold: null
-  check_on_train_epoch_end: null
+  monitor: ??? # quantity to be monitored, must be specified !!!
+  min_delta: 0. # minimum change in the monitored quantity to qualify as an improvement
+  patience: 3 # number of checks with no improvement after which training will be stopped
+  verbose: False # verbosity mode
+  mode: "min" # "max" means higher metric value is better, can be also "min"
+  strict: True # whether to crash the training if monitor is not found in the validation metrics
+  check_finite: True # when set True, stops training when the monitor becomes NaN or infinite
+  stopping_threshold: null # stop training immediately once the monitored quantity reaches this threshold
+  divergence_threshold: null # stop training as soon as the monitored quantity becomes worse than this threshold
+  check_on_train_epoch_end: null # whether to run early stopping at the end of the training epoch
   # log_rank_zero_only: False  # this keyword argument isn't available in stable version

--- a/configs/callbacks/model_checkpoint.yaml
+++ b/configs/callbacks/model_checkpoint.yaml
@@ -1,0 +1,17 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint
+
+model_checkpoint:
+  _target_: pytorch_lightning.callbacks.ModelCheckpoint
+  dirpath: null
+  filename: null
+  monitor: null
+  verbose: False
+  save_last: null
+  save_top_k: 1
+  mode: "min"
+  auto_insert_metric_name: True
+  save_weights_only: False
+  every_n_train_steps: null
+  train_time_interval: null
+  every_n_epochs: null
+  save_on_train_epoch_end: null

--- a/configs/callbacks/model_checkpoint.yaml
+++ b/configs/callbacks/model_checkpoint.yaml
@@ -1,17 +1,19 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.ModelCheckpoint.html
 
+# Save the model periodically by monitoring a quantity.
+# Look at the above link for more detailed information.
 model_checkpoint:
   _target_: pytorch_lightning.callbacks.ModelCheckpoint
-  dirpath: null
-  filename: null
-  monitor: null
-  verbose: False
-  save_last: null
-  save_top_k: 1
-  mode: "min"
-  auto_insert_metric_name: True
-  save_weights_only: False
-  every_n_train_steps: null
-  train_time_interval: null
-  every_n_epochs: null
-  save_on_train_epoch_end: null
+  dirpath: null # directory to save the model file
+  filename: null # checkpoint filename
+  monitor: null # name of the logged metric which determines when model is improving
+  verbose: False # verbosity mode
+  save_last: null # additionally always save an exact copy of the last checkpoint to a file last.ckpt
+  save_top_k: 1 # save k best models (determined by above metric)
+  mode: "min" # "max" means higher metric value is better, can be also "min"
+  auto_insert_metric_name: True # when True, the checkpoints filenames will contain the metric name
+  save_weights_only: False # if True, then only the model’s weights will be saved
+  every_n_train_steps: null # number of training steps between checkpoints
+  train_time_interval: null # checkpoints are monitored at the specified time interval
+  every_n_epochs: null # number of epochs between checkpoints
+  save_on_train_epoch_end: null # whether to run checkpointing at the end of the training epoch or the end of validation

--- a/configs/callbacks/model_summary.yaml
+++ b/configs/callbacks/model_summary.yaml
@@ -1,5 +1,7 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichModelSummary.html#pytorch_lightning.callbacks.RichModelSummary
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichModelSummary.html
 
+# Generates a summary of all layers in a LightningModule with rich text formatting.
+# Look at the above link for more detailed information.
 model_summary:
   _target_: pytorch_lightning.callbacks.RichModelSummary
-  max_depth: 1
+  max_depth: 1 # the maximum depth of layer nesting that the summary will include

--- a/configs/callbacks/model_summary.yaml
+++ b/configs/callbacks/model_summary.yaml
@@ -1,0 +1,5 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichModelSummary.html#pytorch_lightning.callbacks.RichModelSummary
+
+model_summary:
+  _target_: pytorch_lightning.callbacks.RichModelSummary
+  max_depth: 1

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,4 +1,6 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichProgressBar.html#pytorch_lightning.callbacks.RichProgressBar
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichProgressBar.html
 
+# Create a progress bar with rich text formatting.
+# Look at the above link for more detailed information.
 rich_progress_bar:
   _target_: pytorch_lightning.callbacks.RichProgressBar

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,0 +1,4 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.callbacks.RichProgressBar.html#pytorch_lightning.callbacks.RichProgressBar
+
+rich_progress_bar:
+  _target_: pytorch_lightning.callbacks.RichProgressBar


### PR DESCRIPTION
write all callbacks config in just one file is not very clear, i have seperate different callback into their own file, and so if one wants to change some callback, for example model_checkpoint, he can look at model_checkpoint.yaml and just modify the parameters he want in callbacks/default.yaml