### PR TITLE
Add separate job for windows in CI test worfklow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,11 @@ jobs:
           pip install pytest
           pip install protobuf==3.20.0
 
+      - name: Install sh package if bash available
+        shell: bash
+        run: |
+          pip install sh
+
       - name: List dependencies
         run: |
           python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov[toml]
-          pip install protobuf==3.20.0
+          pip install sh
 
       - name: Run tests and collect coverage
         run: pytest --cov src # NEEDS TO BE UPDATED WHEN CHANGING THE NAME OF "src" FOLDER

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     timeout-minutes: 10
@@ -33,11 +33,46 @@ jobs:
           pip install -r requirements.txt
           pip install pytest
           pip install protobuf==3.20.0
+          pip install sh
 
       - name: Install sh package if bash available
         shell: bash
         run: |
           pip install sh
+
+      - name: List dependencies
+        run: |
+          python -m pip list
+
+      - name: Run pytest
+        run: |
+          pytest -v
+
+  run_tests_windows:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
 
       - name: List dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
-          pip install protobuf==3.20.0
           pip install sh
 
       - name: List dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,6 @@ jobs:
           pip install protobuf==3.20.0
           pip install sh
 
-      - name: Install sh package if bash available
-        shell: bash
-        run: |
-          pip install sh
-
       - name: List dependencies
         run: |
           python -m pip list


### PR DESCRIPTION
## What does this PR do?

Adds separate job for windows in `Tests` workflow.

Makes `Tests` workflow install `sh` package if os is not windows.

Otherwise shell tests wouldn't be executed.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
