### PR TITLE
Fix logging metrics in DDP mode (v2)

### DIFF
--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -62,10 +62,10 @@ class MNISTLitModule(LightningModule):
 
     def training_step(self, batch: Any, batch_idx: int):
         loss, preds, targets = self.step(batch)
-        
+
         # set `sync_dist=True` when logging through value, to ensure proper calculation in DDP mode
         self.log("train/loss", loss, on_step=False, on_epoch=True, prog_bar=True, sync_dist=True)
-        
+
         self.train_acc(preds, targets)
         self.log("train/acc", self.train_acc, on_step=False, on_epoch=True, prog_bar=True)
 
@@ -77,20 +77,20 @@ class MNISTLitModule(LightningModule):
     def training_epoch_end(self, outputs: List[Any]):
         # `outputs` is a list of dicts returned from `training_step()`
         pass
-    
+
     def validation_step(self, batch: Any, batch_idx: int):
         loss, preds, targets = self.step(batch)
 
         # set `sync_dist=True` when logging through value, to ensure proper calculation in DDP mode
         self.log("val/loss", loss, on_step=False, on_epoch=True, prog_bar=True, sync_dist=True)
-        
+
         self.val_acc(preds, targets)
         self.log("val/acc", self.val_acc, on_step=False, on_epoch=True, prog_bar=True)
-        
+
         return {"loss": loss, "preds": preds, "targets": targets}
 
     def validation_epoch_end(self, outputs: List[Any]):
-        acc = self.val_acc.compute() # get current validation accuracy
+        acc = self.val_acc.compute()  # get current validation accuracy
         self.val_acc_best.update(acc)
         self.log("val/acc_best", self.val_acc_best, on_epoch=True, prog_bar=True)
 
@@ -99,7 +99,7 @@ class MNISTLitModule(LightningModule):
 
         # set `sync_dist=True` when logging through value, to ensure proper calculation in DDP mode
         self.log("test/loss", loss, on_step=False, on_epoch=True, prog_bar=True, sync_dist=True)
-        
+
         self.test_acc(preds, targets)
         self.log("test/acc", self.test_acc, on_step=False, on_epoch=True, prog_bar=True)
 
@@ -107,7 +107,7 @@ class MNISTLitModule(LightningModule):
 
     def test_epoch_end(self, outputs: List[Any]):
         pass
-    
+
     def configure_optimizers(self):
         """Choose what optimizers and learning-rate schedulers to use in your optimization.
         Normally you'd need one. But in the case of GANs or similar you might have multiple.

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -37,8 +37,7 @@ class MNISTLitModule(LightningModule):
         # loss function
         self.criterion = torch.nn.CrossEntropyLoss()
 
-        # use separate metric instance for train, val and test step
-        # to ensure a proper reduction over the epoch
+        # use separate metric instances for train, val and test step
         self.train_acc = Accuracy()
         self.val_acc = Accuracy()
         self.test_acc = Accuracy()

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -10,7 +10,7 @@ class MNISTLitModule(LightningModule):
     """Example of LightningModule for MNIST classification.
 
     A LightningModule organizes your PyTorch code into 6 sections:
-        - Computations (init).
+        - Computations (init)
         - Train loop (training_step)
         - Validation loop (validation_step)
         - Test loop (test_step)


### PR DESCRIPTION
## What does this PR do?

Fixes #407 

Adds `sync_dist=True` to logging loss, to ensure proper value reduction over processes in DDP mode.

Changes accuracy to be logged through metric object. 

Removes resetting metrics at the end of epochs since it's no longer needed when logging through metric object.

https://torchmetrics.readthedocs.io/en/latest/pages/lightning.html#logging-torchmetrics

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
