### PR TITLE
Fix deprecated TPU import

### DIFF
--- a/tests/helpers/package_available.py
+++ b/tests/helpers/package_available.py
@@ -1,7 +1,7 @@
 import platform
 
 import pkg_resources
-from pytorch_lightning.utilities.xla_device import XLADeviceUtils
+from pytorch_lightning.accelerators import TPUAccelerator
 
 
 def _package_available(package_name: str) -> bool:
@@ -12,7 +12,7 @@ def _package_available(package_name: str) -> bool:
         return False
 
 
-_TPU_AVAILABLE = XLADeviceUtils.tpu_device_exists()
+_TPU_AVAILABLE = TPUAccelerator.is_available()
 
 _IS_WINDOWS = platform.system() == "Windows"
 


### PR DESCRIPTION
## What does this PR do?

Fixes deprecated call for checking if TPU is available during tests.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
