### PR TITLE
Remove object instantiation from `__main__` methods 

### DIFF
--- a/src/data/mnist_datamodule.py
+++ b/src/data/mnist_datamodule.py
@@ -128,11 +128,4 @@ class MNISTDataModule(LightningDataModule):
 
 
 if __name__ == "__main__":
-    import hydra
-    import omegaconf
-    import pyrootutils
-
-    root = pyrootutils.setup_root(__file__, pythonpath=True)
-    cfg = omegaconf.OmegaConf.load(root / "configs" / "datamodule" / "mnist.yaml")
-    cfg.data_dir = str(root / "data")
-    _ = hydra.utils.instantiate(cfg)
+    _ = MNISTDataModule()

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -147,10 +147,4 @@ class MNISTLitModule(LightningModule):
 
 
 if __name__ == "__main__":
-    import hydra
-    import omegaconf
-    import pyrootutils
-
-    root = pyrootutils.setup_root(__file__, pythonpath=True)
-    cfg = omegaconf.OmegaConf.load(root / "configs" / "model" / "mnist.yaml")
-    _ = hydra.utils.instantiate(cfg)
+    _ = MNISTLitModule(None, None, None)

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -95,11 +95,3 @@ def enforce_tags(cfg: DictConfig, save_to_file: bool = False) -> None:
     if save_to_file:
         with open(Path(cfg.paths.output_dir, "tags.log"), "w") as file:
             rich.print(cfg.tags, file=file)
-
-
-if __name__ == "__main__":
-    from hydra import compose, initialize
-
-    with initialize(version_base="1.2", config_path="../../configs"):
-        cfg = compose(config_name="train.yaml", return_hydra_config=False, overrides=[])
-        print_config_tree(cfg, resolve=False, save_to_file=False)


### PR DESCRIPTION
## What does this PR do?

Removes hydra object instantiation in `__main__` functions in some files, because running those files throws errors if they contain local imports, e.g. `import src.utils`, so I don't see a point in keeping these. 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
