### PR TITLE
Add Profiler as a new Config Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The directory structure of new project looks like this:
 │   ├── logger                   <- Logger configs
 │   ├── model                    <- Model configs
 │   ├── paths                    <- Project paths configs
+│   ├── profiler                 <- Profiler configs
 │   ├── trainer                  <- Trainer configs
 │   │
 │   ├── eval.yaml             <- Main config for evaluation

--- a/configs/debug/profiler.yaml
+++ b/configs/debug/profiler.yaml
@@ -7,6 +7,6 @@ defaults:
 
 trainer:
   max_epochs: 1
-  profiler: "simple"
-  # profiler: "advanced"
-  # profiler: "pytorch"
+  profiler: simple.yaml
+  # profiler: "advanced.yaml"
+  # profiler: "pytorch.yaml"

--- a/configs/profiler/advanced.yaml
+++ b/configs/profiler/advanced.yaml
@@ -1,0 +1,7 @@
+#  Details
+# https://pytorch.org/tutorials/intermediate/tensorboard_profiler_tutorial.html#use-profiler-to-record-execution-events
+# https://pytorch-lightning.readthedocs.io/en/stable/tuning/profiler.html
+
+_target_: pytorch_lightning.profiler.AdvancedProfiler
+dirpath: "${paths.output_dir}/" # Default will use from the trainer.log_dir (from TensorBoardLogger) will be used.
+filename: profiler

--- a/configs/profiler/pytorch.yaml
+++ b/configs/profiler/pytorch.yaml
@@ -1,0 +1,11 @@
+# understanding Pytorch Profiler :
+#  https://pytorch.org/tutorials/intermediate/tensorboard_profiler_tutorial.html#use-profiler-to-record-execution-events
+# https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.profilers.PyTorchProfiler.html#pytorch_lightning.profilers.PyTorchProfiler
+
+_target_: pytorch_lightning.profiler.PyTorchProfiler
+
+# Use with Tensorboard for Loafing profile results
+dirpath: "${paths.output_dir}/" # Default will use from the trainer.log_dir (from TensorBoardLogger) will be used.
+filename: profiler
+record_shapes: True
+profile_memory: True

--- a/configs/profiler/simple.yaml
+++ b/configs/profiler/simple.yaml
@@ -1,0 +1,5 @@
+# https://pytorch-lightning.readthedocs.io/en/1.6.4/api/pytorch_lightning.profiler.SimpleProfiler.html#pytorch_lightning.profiler.SimpleProfiler
+
+_target_: pytorch_lightning.profiler.SimpleProfiler
+dirpath: "${paths.output_dir}/" # Default will use from the trainer.log_dir (from TensorBoardLogger) will be used.
+filename: profiler

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -12,6 +12,7 @@ defaults:
   - paths: default.yaml
   - extras: default.yaml
   - hydra: default.yaml
+  - profiler: default.yaml
 
   # experiment configs allow for version control of specific hyperparameters
   # e.g. best hyperparameters for given model and datamodule


### PR DESCRIPTION
## What does this PR do?

1. It adds a new folder with common profiler configs, which were previously only available in Debug mode
2. It enables saving the Profiler output in outputdir with the loggers for better debugging or reading

### Motivation
1. Current flow dumps all the profiler result on the screen which might be hard to consume
3. Adding the file_name  and dir_path in the config allows to save it hand hence better analyze
4. Profiler output like from Pytorch Profiler can be loaded in TensorBoard for better debugging
5. Default behaviour still the same when a full run does not specify any Profiler
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
Fixes #\<issue_number>
-->



## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
