### PR TITLE
Configure flake8 and bandit through pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 
   # python import sorting
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,20 +50,16 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args:
-          [
-            "--extend-ignore",
-            "E203,E402,E501,F401,F841",
-            "--exclude",
-            "logs/*,data/*",
-          ]
+        entry: pflake8
+        additional_dependencies: ["pyproject-flake8"]
 
   # python security linter
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.1"
     hooks:
       - id: bandit
-        args: ["-s", "B101"]
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,15 @@ exclude_lines = [
     "raise NotImplementedError()",
     "if __name__ == .__main__.:",
 ]
+
+[tool.flake8]
+extend-ignore = ["E203", "E402", "E501", "F401", "F841"]
+exclude = ["logs/*","data/*"]
+per-file-ignores = [
+    '__init__.py:F401',
+]
+max-line-length = 99
+count = true
+
+[tool.bandit]
+skips = ["B101", "B311"]


### PR DESCRIPTION
## What does this PR do?

With my auto-linters I ended up configuring flake8 in pyproject.toml anyway. This PR centralizes configs of linters to pyproject.
Pros:
* Centralizes config so can be used by other programs. 
Cons:
* This adds dependencies on optional `bandit[toml]` and `pyproject-flake8`
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->


## Before submitting

- [ x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ x] Did you list all the **breaking changes** introduced by this pull request?
- [ x] Did you **test your PR locally** with `pytest` command?
- [ x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

