### PR TITLE
Encourage resetting all validation metrics when training starts

### DIFF
--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -56,7 +56,9 @@ class MNISTLitModule(LightningModule):
 
     def on_train_start(self):
         # by default lightning executes validation step sanity checks before training starts,
-        # so we need to make sure val_acc_best doesn't store accuracy from these checks
+        # so it's worth to make sure validation metrics don't store results from these checks
+        self.val_loss.reset()
+        self.val_acc.reset()
         self.val_acc_best.reset()
 
     def model_step(self, batch: Any):


### PR DESCRIPTION
## What does this PR do?

Encourage resetting all validation metrics when training starts.

(we reset the metrics to make sure they don't store results from validation sanity checks)

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
