### PR TITLE
fix(docs): fix dead link to lightning docs

### DIFF
--- a/configs/callbacks/early_stopping.yaml
+++ b/configs/callbacks/early_stopping.yaml
@@ -1,7 +1,5 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.callbacks.EarlyStopping.html
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.EarlyStopping.html
 
-# Monitor a metric and stop training when it stops improving.
-# Look at the above link for more detailed information.
 early_stopping:
   _target_: lightning.pytorch.callbacks.EarlyStopping
   monitor: ??? # quantity to be monitored, must be specified !!!

--- a/configs/callbacks/model_checkpoint.yaml
+++ b/configs/callbacks/model_checkpoint.yaml
@@ -1,7 +1,5 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.callbacks.ModelCheckpoint.html
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
 
-# Save the model periodically by monitoring a quantity.
-# Look at the above link for more detailed information.
 model_checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
   dirpath: null # directory to save the model file

--- a/configs/callbacks/model_summary.yaml
+++ b/configs/callbacks/model_summary.yaml
@@ -1,7 +1,5 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.callbacks.RichModelSummary.html
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.RichModelSummary.html
 
-# Generates a summary of all layers in a LightningModule with rich text formatting.
-# Look at the above link for more detailed information.
 model_summary:
   _target_: lightning.pytorch.callbacks.RichModelSummary
   max_depth: 1 # the maximum depth of layer nesting that the summary will include

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,4 +1,4 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.callbacks.RichProgressBar.html
+# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.pytorch.callbacks.RichProgressBar.html
 
 # Create a progress bar with rich text formatting.
 # Look at the above link for more detailed information.

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,6 +1,4 @@
 # https://lightning.ai/docs/pytorch/latest/api/lightning.pytorch.callbacks.RichProgressBar.html
 
-# Create a progress bar with rich text formatting.
-# Look at the above link for more detailed information.
 rich_progress_bar:
   _target_: lightning.pytorch.callbacks.RichProgressBar

--- a/configs/callbacks/rich_progress_bar.yaml
+++ b/configs/callbacks/rich_progress_bar.yaml
@@ -1,4 +1,4 @@
-# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.pytorch.callbacks.RichProgressBar.html
+# https://lightning.ai/docs/pytorch/latest/api/lightning.pytorch.callbacks.RichProgressBar.html
 
 # Create a progress bar with rich text formatting.
 # Look at the above link for more detailed information.


### PR DESCRIPTION
Hi!

This is a very minor fix for a dead link to the Lightning docs in a comment.