### PR TITLE
Set strategy to `ddp` in ddp config

### DIFF
--- a/configs/trainer/ddp.yaml
+++ b/configs/trainer/ddp.yaml
@@ -1,11 +1,7 @@
 defaults:
   - default.yaml
 
-# use "ddp_spawn" instead of "ddp",
-# it's slower but normal "ddp" currently doesn't work ideally with hydra
-# https://github.com/facebookresearch/hydra/issues/2070
-# https://pytorch-lightning.readthedocs.io/en/latest/accelerators/gpu_intermediate.html#distributed-data-parallel-spawn
-strategy: ddp_spawn
+strategy: ddp
 
 accelerator: gpu
 devices: 4


### PR DESCRIPTION
## What does this PR do?

Previously strategy was set to `ddp_spawn` due to problems with normal ddp (https://github.com/ashleve/lightning-hydra-template/issues/393).

Now the issue seems to be fixed in lightning

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
