### PR TITLE
Set `sync_dist=True` when logging best so far validation accuracy

### DIFF
--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -97,7 +97,7 @@ class MNISTLitModule(LightningModule):
         self.val_acc_best(acc)  # update best so far val acc
         # log `val_acc_best` as a value through `.compute()` method, instead of as a metric object
         # otherwise metric would be reset by lightning after each epoch
-        self.log("val/acc_best", self.val_acc_best.compute(), prog_bar=True)
+        self.log("val/acc_best", self.val_acc_best.compute(), sync_dist=True, prog_bar=True)
 
     def test_step(self, batch: Any, batch_idx: int):
         loss, preds, targets = self.model_step(batch)


### PR DESCRIPTION
## What does this PR do?

We set `sync_dist=True` for logging best so far validation accuracy since this metric is logged through value (instead of metric object like all the other metrics in template), so this makes sure it will be synchronized accross devices in multi-gpu setup.

As far as I'm aware, this change doesn't affect the result value of computed metric in this specific case, because synchronization doesn't matter when logging best so far value which is retrieved from other metric object which is already synchronized. 

But it's a good practice to indicate this is what should be done when logging trough value.

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
