### PR TITLE
Lightning import fix in instantiators.py

### DIFF
--- a/src/utils/instantiators.py
+++ b/src/utils/instantiators.py
@@ -1,9 +1,9 @@
 from typing import List
 
 import hydra
+from lightning import Callback
+from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
-from pytorch_lightning import Callback
-from pytorch_lightning.loggers import Logger
 
 from src.utils import pylogger
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Changed "pytorch_lightning" to "lightning" in instantiators.py to avoid import errors since pytorch-lightning package has been replaced with lightning package.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

yaaaaap
