### PR TITLE
Fixing broken pydantic dependency since 2.0+ breaks pytest.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -29,6 +29,7 @@ dependencies:
   - rich=13.*
   - pre-commit=3.*
   - pytest=7.*
+  - pydantic=1.10
 
   # --------- loggers --------- #
   # - wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ pyrootutils     # standardizing the project root setup
 pre-commit      # hooks for applying linters on commit
 rich            # beautiful text formatting in terminal
 pytest          # tests
+pydantic>=1.10, < 2.0  # needed by pytest
 # sh            # for running bash commands in some tests (linux/macos only)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

When install pytest, it'll install the latest version of pydantic and unfortunately pydantic 2.0 and higher introduces breaking changes for pytest that pytest's installation doesn't account for. So, we have to restrict the version of pydantic to be 1.10 or higher, but less than 2.0.

To reproduce, simply install the package requirements (whether through environment.yaml or requirements.txt), verify that pydantic 2.0 or higher has been installed, and run `pytest`.

I got this error:

```
ERROR tests/test_datamodules.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/test_datamodules.py
ERROR tests/test_eval.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/test_eval.py
ERROR tests/test_sweeps.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/test_sweeps.py
ERROR tests/test_train.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/test_train.py
ERROR tests/helpers/package_available.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/helpers/run_if.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
ERROR tests/helpers/run_sh_command.py - ImportError: cannot import name 'ModelMetaclass' from 'pydantic.main' (/private/home/mattie/miniconda3/envs/lightning-hydra-template/lib/python3.11/site-packages/pydantic/main.py)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 11 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================================= 11 errors in 4.45s ============================================================================================================
```

This error makes sense considering that `ModelMetaclass` does not exist in `pydantic.main` for [pydantic 2.0 or higher](https://github.com/pydantic/pydantic/blob/v2.0/pydantic/main.py) but does exist in [1.10.0 and higher](https://github.com/pydantic/pydantic/blob/v1.10.0/pydantic/main.py). Restricting the pydantic version to 1.10+ and less than 2.0 fixes the problem.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

yepyep
