### PR TITLE
Fixed gpu+cpu-based installation requirements 

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -9,6 +9,7 @@ name: myenv
 
 channels:
   - pytorch
+  - nvidia  # comment this out if using cpuonly
   - conda-forge
   - defaults
 
@@ -20,8 +21,12 @@ channels:
 # users, but allows for different minor and patch versions of packages where backwards
 # compatibility is usually guaranteed
 
+# Note: this is assuming a Linux-based installation, for other platforms see https://pytorch.org/get-started/locally/
+
 dependencies:
   - pytorch=2.*
+  - pytorch-cuda=11.8  # comment this out if using cpuonly
+  # - cpuonly          # uncomment if you want a cpu-only installation
   - torchvision=0.*
   - lightning=2.*
   - torchmetrics=0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
+# Note: this is assuming a Linux-based installation, for other platforms see https://pytorch.org/get-started/locally/
+
 # --------- pytorch --------- #
+--extra-index-url https://download.pytorch.org/whl/cu118  # gpu+cpu installation (comment this line if doing cpu-only)
+# --extra-index-url https://download.pytorch.org/whl/cpu  # cpu-only installation (uncomment line if doing cpu-only)
 torch>=2.0.0
 torchvision>=0.15.0
 lightning>=2.0.0


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes gpu+cpu-based installation requirements in environment.yaml (conda-based install) and requirements.txt (pip-based install). Specifically, a gpu+cpu-based installation is assumed as the default method, and so for environment.yaml the necessary channels are added as well as the `pytorch-cuda` package. There's also an option for a cpu-only install. Similarly for a pip-based install, requirements.txt has the `--extra-index-url` specifier for specifying a gpu+cpu-based install or a cpu-only install, as taken from https://pytorch.org/get-started/locally/.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

yus
