### PR TITLE
DDP-related improvements to data module and logging

### DIFF
--- a/configs/data/mnist.yaml
+++ b/configs/data/mnist.yaml
@@ -1,6 +1,6 @@
 _target_: src.data.mnist_datamodule.MNISTDataModule
 data_dir: ${paths.data_dir}
-batch_size: 128
+batch_size: 128 # Needs to be divisible by the number of devices (e.g., if in a distributed setup)
 train_val_test_split: [55_000, 5_000, 10_000]
 num_workers: 0
 pin_memory: False

--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -16,4 +16,4 @@ job_logging:
   handlers:
     file:
       # Incorporates fix from https://github.com/facebookresearch/hydra/pull/2242
-      filename: ${hydra.runtime.output_dir}/${hydra.job.name}.log
+      filename: ${hydra.runtime.output_dir}/${task_name}.log

--- a/src/data/mnist_datamodule.py
+++ b/src/data/mnist_datamodule.py
@@ -115,11 +115,12 @@ class MNISTDataModule(LightningDataModule):
         :param stage: The stage to setup. Either `"fit"`, `"validate"`, `"test"`, or `"predict"`. Defaults to ``None``.
         """
         # Divide batch size by the number of devices.
-        if self.hparams.batch_size % self.trainer.world_size != 0:
-            raise RuntimeError(
-                f"Batch size ({self.hparams.batch_size}) is not divisible by the number of devices ({self.trainer.world_size})."
-            )
-        self.batch_size_per_device = self.hparams.batch_size // self.trainer.world_size
+        if self.trainer is not None:
+            if self.hparams.batch_size % self.trainer.world_size != 0:
+                raise RuntimeError(
+                    f"Batch size ({self.hparams.batch_size}) is not divisible by the number of devices ({self.trainer.world_size})."
+                )
+            self.batch_size_per_device = self.hparams.batch_size // self.trainer.world_size
 
         # load and split datasets only if not loaded already
         if not self.data_train and not self.data_val and not self.data_test:

--- a/src/data/mnist_datamodule.py
+++ b/src/data/mnist_datamodule.py
@@ -83,6 +83,8 @@ class MNISTDataModule(LightningDataModule):
         self.data_val: Optional[Dataset] = None
         self.data_test: Optional[Dataset] = None
 
+        self.batch_size_per_device = batch_size
+
     @property
     def num_classes(self) -> int:
         """Get the number of classes.
@@ -112,6 +114,13 @@ class MNISTDataModule(LightningDataModule):
 
         :param stage: The stage to setup. Either `"fit"`, `"validate"`, `"test"`, or `"predict"`. Defaults to ``None``.
         """
+        # Divide batch size by the number of devices.
+        if self.hparams.batch_size % self.trainer.world_size != 0:
+            raise RuntimeError(
+                f"Batch size ({self.hparams.batch_size}) is not divisible by the number of devices ({self.trainer.world_size})."
+            )
+        self.batch_size_per_device = self.hparams.batch_size // self.trainer.world_size
+
         # load and split datasets only if not loaded already
         if not self.data_train and not self.data_val and not self.data_test:
             trainset = MNIST(self.hparams.data_dir, train=True, transform=self.transforms)
@@ -130,7 +139,7 @@ class MNISTDataModule(LightningDataModule):
         """
         return DataLoader(
             dataset=self.data_train,
-            batch_size=self.hparams.batch_size,
+            batch_size=self.batch_size_per_device,
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=True,
@@ -143,7 +152,7 @@ class MNISTDataModule(LightningDataModule):
         """
         return DataLoader(
             dataset=self.data_val,
-            batch_size=self.hparams.batch_size,
+            batch_size=self.batch_size_per_device,
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=False,
@@ -156,7 +165,7 @@ class MNISTDataModule(LightningDataModule):
         """
         return DataLoader(
             dataset=self.data_test,
-            batch_size=self.hparams.batch_size,
+            batch_size=self.batch_size_per_device,
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=False,

--- a/src/eval.py
+++ b/src/eval.py
@@ -24,12 +24,18 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 # more info: https://github.com/ashleve/rootutils
 # ------------------------------------------------------------------------------------ #
 
-from src import utils
+from src.utils import (
+    extras,
+    get_ranked_pylogger,
+    instantiate_loggers,
+    log_hyperparameters,
+    task_wrapper,
+)
 
-log = utils.get_pylogger(__name__)
+log = get_ranked_pylogger(__name__)
 
 
-@utils.task_wrapper
+@task_wrapper
 def evaluate(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Evaluates given checkpoint on a datamodule testset.
 
@@ -48,7 +54,7 @@ def evaluate(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     model: LightningModule = hydra.utils.instantiate(cfg.model)
 
     log.info("Instantiating loggers...")
-    logger: List[Logger] = utils.instantiate_loggers(cfg.get("logger"))
+    logger: List[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
     trainer: Trainer = hydra.utils.instantiate(cfg.trainer, logger=logger)
@@ -63,7 +69,7 @@ def evaluate(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
 
     if logger:
         log.info("Logging hyperparameters!")
-        utils.log_hyperparameters(object_dict)
+        log_hyperparameters(object_dict)
 
     log.info("Starting testing!")
     trainer.test(model=model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)
@@ -84,7 +90,7 @@ def main(cfg: DictConfig) -> None:
     """
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
-    utils.extras(cfg)
+    extras(cfg)
 
     evaluate(cfg)
 

--- a/src/eval.py
+++ b/src/eval.py
@@ -25,14 +25,14 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 # ------------------------------------------------------------------------------------ #
 
 from src.utils import (
+    RankedLogger,
     extras,
-    get_ranked_pylogger,
     instantiate_loggers,
     log_hyperparameters,
     task_wrapper,
 )
 
-log = get_ranked_pylogger(__name__)
+log = RankedLogger(__name__, rank_zero_only=True)
 
 
 @task_wrapper

--- a/src/train.py
+++ b/src/train.py
@@ -27,16 +27,16 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 # ------------------------------------------------------------------------------------ #
 
 from src.utils import (
+    RankedLogger,
     extras,
     get_metric_value,
-    get_ranked_pylogger,
     instantiate_callbacks,
     instantiate_loggers,
     log_hyperparameters,
     task_wrapper,
 )
 
-log = get_ranked_pylogger(__name__)
+log = RankedLogger(__name__, rank_zero_only=True)
 
 
 @task_wrapper

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,5 @@
 from src.utils.instantiators import instantiate_callbacks, instantiate_loggers
 from src.utils.logging_utils import log_hyperparameters
-from src.utils.pylogger import get_ranked_pylogger
+from src.utils.pylogger import RankedLogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
 from src.utils.utils import extras, get_metric_value, task_wrapper

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,5 @@
 from src.utils.instantiators import instantiate_callbacks, instantiate_loggers
 from src.utils.logging_utils import log_hyperparameters
-from src.utils.pylogger import get_pylogger
+from src.utils.pylogger import get_ranked_pylogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
 from src.utils.utils import extras, get_metric_value, task_wrapper

--- a/src/utils/instantiators.py
+++ b/src/utils/instantiators.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 
 from src.utils import pylogger
 
-log = pylogger.get_ranked_pylogger(__name__)
+log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 def instantiate_callbacks(callbacks_cfg: DictConfig) -> List[Callback]:

--- a/src/utils/instantiators.py
+++ b/src/utils/instantiators.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 
 from src.utils import pylogger
 
-log = pylogger.get_pylogger(__name__)
+log = pylogger.get_ranked_pylogger(__name__)
 
 
 def instantiate_callbacks(callbacks_cfg: DictConfig) -> List[Callback]:

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict
 
-from lightning.pytorch.utilities import rank_zero_only
+from lightning_utilities.core.rank_zero import rank_zero_only
 from omegaconf import OmegaConf
 
 from src.utils import pylogger
 
-log = pylogger.get_pylogger(__name__)
+log = pylogger.get_ranked_pylogger(__name__)
 
 
 @rank_zero_only

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -5,7 +5,7 @@ from omegaconf import OmegaConf
 
 from src.utils import pylogger
 
-log = pylogger.get_ranked_pylogger(__name__)
+log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 @rank_zero_only

--- a/src/utils/pylogger.py
+++ b/src/utils/pylogger.py
@@ -1,21 +1,50 @@
 import logging
+from functools import wraps
+from typing import Callable, Optional, ParamSpec, TypeVar
 
-from lightning.pytorch.utilities import rank_zero_only
+from lightning_utilities.core.rank_zero import rank_prefixed_message, rank_zero_only
 
 
-def get_pylogger(name: str = __name__) -> logging.Logger:
-    """Initializes a multi-GPU-friendly python command line logger.
+def get_ranked_pylogger(name: str = __name__) -> logging.Logger:
+    """Initializes a multi-GPU-friendly python command line logger that logs on all processes with
+    their rank prefixed in the log message.
 
     :param name: The name of the logger, defaults to ``__name__``.
 
     :return: A logger object.
     """
+    T = TypeVar("T")
+    P = ParamSpec("P")
+
+    def _rank_prefixed_log(fn: Callable[P, T]) -> Callable[P, Optional[T]]:
+        """Wrap a logging function to prefix its message with the rank of the process it's being
+        logged from.
+
+        If `'rank'` is provided in the wrapped functions kwargs, then the log will only occur on
+        that rank/process.
+        """
+
+        @wraps(fn)
+        def wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
+            rank = getattr(rank_zero_only, "rank", None)
+            if rank is None:
+                raise RuntimeError("The `rank_zero_only.rank` needs to be set before use")
+            rank_to_log = kwargs.get("rank", None)
+            msg = rank_prefixed_message(args[0], rank)
+            if rank_to_log is None:
+                return fn(msg=msg, *args[1:], **kwargs)
+            elif rank == rank_to_log:
+                return fn(msg=msg, *args[1:], **kwargs)
+            else:
+                return None
+
+        return wrapped_fn
+
     logger = logging.getLogger(name)
 
-    # this ensures all logging levels get marked with the rank zero decorator
-    # otherwise logs would get multiplied for each GPU process in multi-GPU setup
+    # This ensures all logging levels get marked with the _rank_prefixed_log decorator.
     logging_levels = ("debug", "info", "warning", "error", "exception", "fatal", "critical")
     for level in logging_levels:
-        setattr(logger, level, rank_zero_only(getattr(logger, level)))
+        setattr(logger, level, _rank_prefixed_log(getattr(logger, level)))
 
     return logger

--- a/src/utils/pylogger.py
+++ b/src/utils/pylogger.py
@@ -1,21 +1,30 @@
 import logging
+from typing import Mapping, Optional
 
 from lightning_utilities.core.rank_zero import rank_prefixed_message, rank_zero_only
 
 
 class RankedLogger(logging.LoggerAdapter):
-    def __init__(self, name: str = __name__, rank_zero_only: bool = False) -> None:
+    """A multi-GPU-friendly python command line logger."""
+
+    def __init__(
+        self,
+        name: str = __name__,
+        rank_zero_only: bool = False,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
         """Initializes a multi-GPU-friendly python command line logger that logs on all processes
         with their rank prefixed in the log message.
 
         :param name: The name of the logger. Default is ``__name__``.
         :param rank_zero_only: Whether to force all logs to only occur on the rank zero process. Default is `False`.
+        :param extra: (Optional) A dict-like object which provides contextual information. See `logging.LoggerAdapter`.
         """
         logger = logging.getLogger(name)
-        super().__init__(logger)
+        super().__init__(logger=logger, extra=extra)
         self.rank_zero_only = rank_zero_only
 
-    def log(self, level, msg, rank=None, *args, **kwargs) -> None:
+    def log(self, level: int, msg: str, rank: Optional[int] = None, *args, **kwargs) -> None:
         """Delegate a log call to the underlying logger, after prefixing its message with the rank
         of the process it's being logged from. If `'rank'` is provided, then the log will only
         occur on that rank/process.

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -5,13 +5,13 @@ import rich
 import rich.syntax
 import rich.tree
 from hydra.core.hydra_config import HydraConfig
-from lightning.pytorch.utilities import rank_zero_only
+from lightning_utilities.core.rank_zero import rank_zero_only
 from omegaconf import DictConfig, OmegaConf, open_dict
 from rich.prompt import Prompt
 
 from src.utils import pylogger
 
-log = pylogger.get_pylogger(__name__)
+log = pylogger.get_ranked_pylogger(__name__)
 
 
 @rank_zero_only

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -11,7 +11,7 @@ from rich.prompt import Prompt
 
 from src.utils import pylogger
 
-log = pylogger.get_ranked_pylogger(__name__)
+log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 @rank_zero_only

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 
 from src.utils import pylogger, rich_utils
 
-log = pylogger.get_pylogger(__name__)
+log = pylogger.get_ranked_pylogger(__name__)
 
 
 def extras(cfg: DictConfig) -> None:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 
 from src.utils import pylogger, rich_utils
 
-log = pylogger.get_ranked_pylogger(__name__)
+log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 def extras(cfg: DictConfig) -> None:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

1. Changed the pylogger to be rank-aware, such that logged messages will have the rank of the process prefixed. It also has the capability of logging to a specific rank if the user wishes to, thereby covering the previous pylogger's use-case of rank-zero logging while providing greater logging flexibility. By default, the new pylogger is unrestricted in the ranks it logs to so as to provide greater clarity as to which process the current log is being executed in (e.g., when instantiating models and such, it's useful to know that it's happening on multiple processes).
2. The MNIST DataModule's batch size is now divided by the number of processes used in a DDP setup, so as to keep training dynamics more consistent/comparable when running multiple training scripts, each with a different number of devices.
3. The log file saved by the Hydra colorlog plugin is now consistent across devices when training in a DDP setup. This means that all processes will log to the same file, and because the new pylogger provides rank information, it is easy for the user to tell from which process the log came from. This is in contrast to before where one file called `train.log` would be created for the rank 0 process and `train_ddp_process_{rank}.log` would be created for all the other ranks, making it confusing to read through logs in a DDP setup.


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [~] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?
y

Make sure you had fun coding 🙃
