### PR TITLE
Fix Typo in tests/test_train.py docstring

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -37,14 +37,14 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
 @RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
-    """Train 1 epoch on CPU with mixed-precision.
+    """Train 1 epoch on GPU with mixed-precision.
 
     :param cfg_train: A DictConfig containing a valid training configuration.
     """
     HydraConfig().set_config(cfg_train)
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
-        cfg_train.trainer.accelerator = "cpu"
+        cfg_train.trainer.accelerator = "gpu"
         cfg_train.trainer.precision = 16
     train(cfg_train)
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -37,7 +37,7 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
 @RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
-    """Train 1 epoch on GPU with mixed-precision.
+    """Train 1 epoch on CPU with mixed-precision.
 
     :param cfg_train: A DictConfig containing a valid training configuration.
     """


### PR DESCRIPTION
Fix typo in test docstring.

## What does this PR do?

The test reads like it should and is executed on CPU.
Now the test docstring is consistend.

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Indeed :)
