### PR TITLE
Add simple FSDP support to MNIST example `LightningModule`

### DIFF
--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -198,7 +198,7 @@ class MNISTLitModule(LightningModule):
 
         :return: A dict containing the configured optimizers and learning-rate schedulers to be used for training.
         """
-        optimizer = self.hparams.optimizer(params=self.parameters())
+        optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
         if self.hparams.scheduler is not None:
             scheduler = self.hparams.scheduler(optimizer=optimizer)
             return {


### PR DESCRIPTION
## What does this PR do?

* Updates the `mnist_module.py` to reference the `Trainer`'s version of `parameters()` e.g., for FSDP support
* Note: Without referencing `parameters()` in this way, `Lightning` strategies such as FSDP will not be able to successfully wrap one's model parameters. Even more importantly: if one were to train a model while referencing `self.parameters()` and then attempt to re-train the model when referencing `self.trainer.model.parameters()`, `Lightning` 2.0 will (currently) raise an Exception, preventing one from resuming any training with the original checkpoint. That is why I think this change is important for everyone to use as a default.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
