### PR TITLE
Resolve Hydra ListConfig objects

### DIFF
--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -12,7 +12,15 @@ defaults:
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
-tags: ["mnist", "simple_dense_net"]
+# tags are a list of string that can be defined either as a JSON flow-style (in-line) list
+# e.g. ["mnist", "simple_dense_net", ...] or as a YAML block-style array list like below.
+# tags can even be dynamically interpolated at runtime.
+# NOTE: dynamic interpolation only works in block-style lists like below, not flow-style lists.
+tags:
+  - "mnist"
+  - "simple_dense_net"
+  - ${task_name}  # will be dynamically interpolated
+  - batch_size_${data.batch_size} # will also be dynamically interpolated
 
 seed: 12345
 

--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -12,10 +12,11 @@ defaults:
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
-# tags are a list of string that can be defined either as a JSON flow-style (in-line) list
-# e.g. ["mnist", "simple_dense_net", ...] or as a YAML block-style array list like below.
-# tags can even be dynamically interpolated at runtime.
-# NOTE: dynamic interpolation only works in block-style lists like below, not flow-style lists.
+# `tags` is a list of strings, defined either:
+# 1. In JSON flow-style: ["mnist", "simple_dense_net", ...]
+# 2. As a YAML block-style array, as shown below.
+# Tags can be interpolated dynamically at runtime.
+# NOTE: Dynamic interpolation is only supported in block-style lists, not flow-style.
 tags:
   - "mnist"
   - "simple_dense_net"

--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -19,7 +19,7 @@ defaults:
 tags:
   - "mnist"
   - "simple_dense_net"
-  - ${task_name}  # will be dynamically interpolated
+  - ${task_name} # will be dynamically interpolated
   - batch_size_${data.batch_size} # will also be dynamically interpolated
 
 seed: 12345

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -6,7 +6,7 @@ import rich.syntax
 import rich.tree
 from hydra.core.hydra_config import HydraConfig
 from lightning_utilities.core.rank_zero import rank_zero_only
-from omegaconf import ListConfig, DictConfig, OmegaConf, open_dict
+from omegaconf import DictConfig, ListConfig, OmegaConf, open_dict
 from rich.prompt import Prompt
 
 from src.utils import pylogger

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -6,7 +6,7 @@ import rich.syntax
 import rich.tree
 from hydra.core.hydra_config import HydraConfig
 from lightning_utilities.core.rank_zero import rank_zero_only
-from omegaconf import DictConfig, OmegaConf, open_dict
+from omegaconf import ListConfig, DictConfig, OmegaConf, open_dict
 from rich.prompt import Prompt
 
 from src.utils import pylogger
@@ -58,7 +58,7 @@ def print_config_tree(
         branch = tree.add(field, style=style, guide_style=style)
 
         config_group = cfg[field]
-        if isinstance(config_group, DictConfig):
+        if isinstance(config_group, DictConfig | ListConfig):
             branch_content = OmegaConf.to_yaml(config_group, resolve=resolve)
         else:
             branch_content = str(config_group)

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -58,7 +58,7 @@ def print_config_tree(
         branch = tree.add(field, style=style, guide_style=style)
 
         config_group = cfg[field]
-        if isinstance(config_group, DictConfig | ListConfig):
+        if isinstance(config_group, (DictConfig, ListConfig)):
             branch_content = OmegaConf.to_yaml(config_group, resolve=resolve)
         else:
             branch_content = str(config_group)


### PR DESCRIPTION
## What does this PR do?
Resolves Hydra `ListConfig` objects so that dynamic inteploation works when printing config tree.
Also updated the `example.yaml` experiment to showcase the use.

Fixes https://github.com/ashleve/lightning-hydra-template/issues/611

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

:rocket: 
