### PR TITLE
fix: best checkpoint not found issue

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -91,7 +91,7 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     if cfg.get("test"):
         log.info("Starting testing!")
         ckpt_path = trainer.checkpoint_callback.best_model_path
-        if ckpt_path == "":
+        if ckpt_path:
             log.warning("Best ckpt not found! Using current weights for testing...")
             ckpt_path = None
         trainer.test(model=model, datamodule=datamodule, ckpt_path=ckpt_path)


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where Lightning saves "best ckpt" with absolute paths in each checkpoint. These are not copied during fine-tuning or continue training, causing issues if the "best ckpt" is deleted or moved.

With this change, the system will use current weights for testing if the "best ckpt" is not found, ensuring smooth execution of fine-tuning and continue training stages.

The changes made are as follows:
```python
if ckpt_path == "":
    log.warning("Best ckpt not found! Using current weights for testing...")
    ckpt_path = None
```

to

```python
if not ckpt_path:
    log.warning("Best ckpt not found! Using current weights for testing...")
    ckpt_path = None
```

Fixes #621 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
