### PR TITLE
Fix an issue where the seed is not used when it is 0

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -51,7 +51,7 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     :return: A tuple with metrics and dict with all instantiated objects.
     """
     # set seed for random number generators in pytorch, numpy and python.random
-    if cfg.get("seed"):
+    if cfg.get("seed") is not None:
         L.seed_everything(cfg.seed, workers=True)
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")


### PR DESCRIPTION
## What does this PR do?

This PR fix allows us to use the value 0 as the seed. Currently, when the seed is configured as 0 in the config file, the seed will not be used in `train.py` as it will not bypass the `if cfg.get("seed"):` check. By checking whether `cfg.get("seed")` is the `None` type, it'll let us set the seed to 0.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

